### PR TITLE
Allow globbed allowedAttributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var htmlparser = require('htmlparser2');
 var _ = require('lodash');
 var he = require('he');
+var quoteRegexp = require('regexp-quote');
 
 module.exports = sanitizeHtml;
 
@@ -59,7 +60,7 @@ function sanitizeHtml(html, options, _recursing) {
       var globRegex = [];
       _.each(attributes, function(name) {
         if(name.indexOf('*') >= 0) {
-          globRegex.push(name.replace(/\*/g, '.*'));
+          globRegex.push(quoteRegexp(name).replace(/\\\*/g, '.*'));
         } else {
           allowedAttributesMap[tag][name] = true;
         }

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function sanitizeHtml(html, options, _recursing) {
           allowedAttributesMap[tag][name] = true;
         }
       });
-      allowedAttributesGlobMap[tag] = new RegExp('^' + globRegex.join('|') + '$');
+      allowedAttributesGlobMap[tag] = new RegExp('^(' + globRegex.join('|') + ')$');
     });
   }
   var allowedClassesMap = {};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "he": "~0.4.1",
     "htmlparser2": "3.7.x",
-    "lodash": "2.4.x"
+    "lodash": "2.4.x",
+    "regexp-quote": "0.0.0"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -312,4 +312,12 @@ describe('sanitizeHtml', function() {
       }), '<a data-my-foo="hello">click me</a>'
     );
   });
+  it('should quote regex chars in attributes specified as globs', function() {
+    assert.equal(
+      sanitizeHtml('<a data-b.c="#test" data-bcc="remove this">click me</a>', {
+        allowedTags: [ 'a' ],
+        allowedAttributes: { a: ['data-b.*'] }
+      }), '<a data-b.c="#test">click me</a>'
+    );
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -298,4 +298,18 @@ describe('sanitizeHtml', function() {
       '<<a>a href="javascript:evil"/></a>'
     );
   });
+  it('should allow attributes to be specified as globs', function() {
+    assert.equal(
+      sanitizeHtml('<a data-target="#test" data-foo="hello">click me</a>', {
+        allowedTags: [ 'a' ],
+        allowedAttributes: { a: ['data-*'] }
+      }), '<a data-target="#test" data-foo="hello">click me</a>'
+    );
+    assert.equal(
+      sanitizeHtml('<a data-target="#test" data-my-foo="hello">click me</a>', {
+        allowedTags: [ 'a' ],
+        allowedAttributes: { a: ['data-*-foo'] }
+      }), '<a data-my-foo="hello">click me</a>'
+    );
+  });
 });


### PR DESCRIPTION
Basic implementation of #4 that is sufficient for my use cases.  If you have any concerns or suggestions, let me know.

Basically what happens is that if an allowedAttribute has a `'*'` in it, that is replaced by `'.*'` and a single regular expression is built to test allowed glob attributes.

Example:

For `allowedAttributes: ['data-*', '*-foo']`, `allowedAttributesGlobMap[tag]` would be `/^(data-.*|.*-foo)$/`.