### PR TITLE
Configurable text escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ If you do not specify `allowedTags` or `allowedAttributes` our default list is a
     // Lots of these won't come up by default because we don't allow them
     selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta' ],
     // URL schemes we permit
-    allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ]
+    allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
+    escapeText: true
 
 "What if I want to allow all tags or all attributes?"
 

--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ function sanitizeHtml(html, options, _recursing) {
             }
             result += ' ' + a;
             if (value.length) {
-              result += '="' + escapeHtml(value) + '"';
+              result += '="' + (options.escapeText ? escapeHtml(value) : value) + '"';
             }
           } else {
             delete frame.attribs[a];
@@ -163,7 +163,7 @@ function sanitizeHtml(html, options, _recursing) {
         return;
       }
       var tag = stack[stack.length-1] && stack[stack.length-1].tag;
-      if (_.has(nonTextTagsMap, tag)) {
+      if (_.has(nonTextTagsMap, tag) || !options.escapeText) {
         result += text;
       } else {
         result += escapeHtml(text);
@@ -268,7 +268,8 @@ sanitizeHtml.defaults = {
   // Lots of these won't come up by default because we don't allow them
   selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta' ],
   // URL schemes we permit
-  allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ]
+  allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
+  escapeText: true
 };
 
 sanitizeHtml.simpleTransform = function(newTagName, newAttribs, merge) {

--- a/test/test.js
+++ b/test/test.js
@@ -333,4 +333,11 @@ describe('sanitizeHtml', function() {
       }), '&quot;normal text&quot;<style>body { background-image: url("image.test"); }</style>'
     );
   });
+  it('should not escape text when turned off', function() {
+    assert.equal(
+      sanitizeHtml('"nonescaped & text"<script>"this is code"</script>', {
+        escapeText: false,
+    }), '"nonescaped & text"'
+    );
+  });
 });


### PR DESCRIPTION
By default all text is escaped, too.  Added a new escapeText parameter in case you want your text to be left alone.