### PR TITLE
[feat] Add Per Tag Scheme Definitions

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,8 +241,8 @@ function sanitizeHtml(html, options, _recursing) {
       return false;
     }
     var scheme = matches[1].toLowerCase();
-    return (!_.contains(options.allowedSchemes[name], scheme) &&
-    !_.contains(options.allowedSchemes.sanitizeDefault, scheme));
+    return (!_.contains(options.allowedSchemesPerTag[name], scheme) &&
+    !_.contains(options.allowedSchemes, scheme));
   }
 
   function filterClasses(classes, allowed) {
@@ -271,9 +271,8 @@ sanitizeHtml.defaults = {
   // Lots of these won't come up by default because we don't allow them
   selfClosing: ['img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta'],
   // URL schemes we permit
-  allowedSchemes: {
-    sanitizeDefault: ['http', 'https', 'ftp', 'mailto']
-  }
+  allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
+  allowedSchemesPerTag: {}
 };
 
 sanitizeHtml.simpleTransform = function(newTagName, newAttribs, merge) {

--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ function sanitizeHtml(html, options, _recursing) {
           if (!allowedAttributesMap || _.has(allowedAttributesMap[name], a) || (_.has(allowedAttributesGlobMap, name) &&
               allowedAttributesGlobMap[name].test(a))) {
             if ((a === 'href') || (a === 'src')) {
-              if (naughtyHref(value)) {
+              if (naughtyHref(name, value)) {
                 delete frame.attribs[a];
                 return;
               }
@@ -225,7 +225,7 @@ function sanitizeHtml(html, options, _recursing) {
     return s.replace(/\&/g, '&amp;').replace(/</g, '&lt;').replace(/\>/g, '&gt;').replace(/\"/g, '&quot;');
   }
 
-  function naughtyHref(href) {
+  function naughtyHref(name, href) {
     // Browsers ignore character codes of 32 (space) and below in a surprising
     // number of situations. Start reading here:
     // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#Embedded_tab
@@ -241,7 +241,8 @@ function sanitizeHtml(html, options, _recursing) {
       return false;
     }
     var scheme = matches[1].toLowerCase();
-    return (!_.contains(options.allowedSchemes, scheme));
+    return (!_.contains(options.allowedSchemes[name], scheme) &&
+    !_.contains(options.allowedSchemes.sanitizeDefault, scheme));
   }
 
   function filterClasses(classes, allowed) {
@@ -260,17 +261,19 @@ function sanitizeHtml(html, options, _recursing) {
 // programmatically if you wish
 
 sanitizeHtml.defaults = {
-  allowedTags: [ 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'hr', 'br', 'div', 'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre' ],
+  allowedTags: ['h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol', 'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'hr', 'br', 'div', 'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre'],
   allowedAttributes: {
-    a: [ 'href', 'name', 'target' ],
+    a: ['href', 'name', 'target'],
     // We don't currently allow img itself by default, but this
     // would make sense if we did
-    img: [ 'src' ]
+    img: ['src']
   },
   // Lots of these won't come up by default because we don't allow them
-  selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta' ],
+  selfClosing: ['img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta'],
   // URL schemes we permit
-  allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ]
+  allowedSchemes: {
+    sanitizeDefault: ['http', 'https', 'ftp', 'mailto']
+  }
 };
 
 sanitizeHtml.simpleTransform = function(newTagName, newAttribs, merge) {

--- a/test/test.js
+++ b/test/test.js
@@ -184,10 +184,8 @@ describe('sanitizeHtml', function() {
         // teeny-tiny valid transparent GIF in a data URL
         '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />',
         {
-          allowedTags: ['img', 'p'],
-          allowedSchemes: {
-            sanitizeDefault: ['data', 'http']
-          }
+          allowedTags: [ 'img', 'p' ],
+          allowedSchemes: [ 'data', 'http' ]
         }
       ),
       '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />'
@@ -200,10 +198,10 @@ describe('sanitizeHtml', function() {
         '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" /><a href="https://www.example.com"></a>',
         {
           allowedTags: ['img', 'a'],
-          allowedSchemes: {
+          allowedSchemes: ['http'],
+          allowedSchemesPerTag: {
             img: [],
-            a: ['https'],
-            sanitizeDefault: ['http']
+            a: ['https']
           }
         }
       ),

--- a/test/test.js
+++ b/test/test.js
@@ -20,16 +20,16 @@ describe('sanitizeHtml', function() {
     assert.equal(sanitizeHtml('<div><wiggly>Hello</wiggly></div>'), '<div>Hello</div>');
   });
   it('should accept a custom list of allowed tags', function() {
-    assert.equal(sanitizeHtml('<blue><red><green>Cheese</green></red></blue>', { allowedTags: [ 'blue', 'green' ] }), '<blue><green>Cheese</green></blue>');
+    assert.equal(sanitizeHtml('<blue><red><green>Cheese</green></red></blue>', {allowedTags: ['blue', 'green']}), '<blue><green>Cheese</green></blue>');
   });
   it('should reject attributes not whitelisted', function() {
     assert.equal(sanitizeHtml('<a href="foo.html" whizbang="whangle">foo</a>'), '<a href="foo.html">foo</a>');
   });
   it('should accept a custom list of allowed attributes per element', function() {
-    assert.equal(sanitizeHtml('<a href="foo.html" whizbang="whangle">foo</a>', { allowedAttributes: { a: [ 'href', 'whizbang' ] } } ), '<a href="foo.html" whizbang="whangle">foo</a>');
+    assert.equal(sanitizeHtml('<a href="foo.html" whizbang="whangle">foo</a>', {allowedAttributes: {a: ['href', 'whizbang']}}), '<a href="foo.html" whizbang="whangle">foo</a>');
   });
   it('should clean up unclosed img tags and p tags', function() {
-    assert.equal(sanitizeHtml('<img src="foo.jpg"><p>Whee<p>Again<p>Wow<b>cool</b>', { allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ])}), '<img src="foo.jpg" /><p>Whee</p><p>Again</p><p>Wow<b>cool</b></p>');
+    assert.equal(sanitizeHtml('<img src="foo.jpg"><p>Whee<p>Again<p>Wow<b>cool</b>', {allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img'])}), '<img src="foo.jpg" /><p>Whee</p><p>Again</p><p>Wow<b>cool</b></p>');
   });
   it('should reject hrefs that are not relative, ftp, http, https or mailto', function() {
     assert.equal(sanitizeHtml('<a href="http://google.com">google</a><a href="https://google.com">https google</a><a href="ftp://example.com">ftp</a><a href="mailto:test@test.com">mailto</a><a href="/relative.html">relative</a><a href="javascript:alert(0)">javascript</a>'), '<a href="http://google.com">google</a><a href="https://google.com">https google</a><a href="ftp://example.com">ftp</a><a href="mailto:test@test.com">mailto</a><a href="/relative.html">relative</a><a>javascript</a>');
@@ -78,80 +78,93 @@ describe('sanitizeHtml', function() {
     assert.equal(sanitizeHtml('<a href="hello.html">Hi</a>'), '<a href="hello.html">Hi</a>');
   });
   it('should replace ol to ul', function() {
-    assert.equal(sanitizeHtml('<ol><li>Hello world</li></ol>', { transformTags: {ol: 'ul'} }), '<ul><li>Hello world</li></ul>');
+    assert.equal(sanitizeHtml('<ol><li>Hello world</li></ol>', {transformTags: {ol: 'ul'}}), '<ul><li>Hello world</li></ul>');
   });
   it('should replace ol to ul and add class attribute with foo value', function() {
-    assert.equal(sanitizeHtml('<ol><li>Hello world</li></ol>', { transformTags: {ol: sanitizeHtml.simpleTransform('ul', {class: 'foo'})}, allowedAttributes: { ul: ['class'] } }), '<ul class="foo"><li>Hello world</li></ul>');
+    assert.equal(sanitizeHtml('<ol><li>Hello world</li></ol>', {
+      transformTags: {ol: sanitizeHtml.simpleTransform('ul', {class: 'foo'})},
+      allowedAttributes: {ul: ['class']}
+    }), '<ul class="foo"><li>Hello world</li></ul>');
   });
   it('should replace ol to ul, left attributes foo and bar untouched, remove baz attribute and add class attributte with foo value', function() {
-    assert.equal(sanitizeHtml('<ol foo="foo" bar="bar" baz="baz"><li>Hello world</li></ol>', { transformTags: {ol: sanitizeHtml.simpleTransform('ul', {class: 'foo'})}, allowedAttributes: { ul: ['foo', 'bar', 'class'] } }), '<ul foo="foo" bar="bar" class="foo"><li>Hello world</li></ul>');
+    assert.equal(sanitizeHtml('<ol foo="foo" bar="bar" baz="baz"><li>Hello world</li></ol>', {
+      transformTags: {ol: sanitizeHtml.simpleTransform('ul', {class: 'foo'})},
+      allowedAttributes: {ul: ['foo', 'bar', 'class']}
+    }), '<ul foo="foo" bar="bar" class="foo"><li>Hello world</li></ul>');
   });
   it('should replace ol to ul and replace all attributes to class attribute with foo value', function() {
-    assert.equal(sanitizeHtml('<ol foo="foo" bar="bar" baz="baz"><li>Hello world</li></ol>', { transformTags: {ol: sanitizeHtml.simpleTransform('ul', {class: 'foo'}, false)}, allowedAttributes: { ul: ['foo', 'bar', 'class'] } }), '<ul class="foo"><li>Hello world</li></ul>');
+    assert.equal(sanitizeHtml('<ol foo="foo" bar="bar" baz="baz"><li>Hello world</li></ol>', {
+      transformTags: {ol: sanitizeHtml.simpleTransform('ul', {class: 'foo'}, false)},
+      allowedAttributes: {ul: ['foo', 'bar', 'class']}
+    }), '<ul class="foo"><li>Hello world</li></ul>');
   });
   it('should replace ol to ul and add attribute class with foo value and attribute bar with bar value', function() {
-    assert.equal(sanitizeHtml('<ol><li>Hello world</li></ol>', { transformTags: {ol: function(tagName, attribs){
-      attribs.class = 'foo';
-      attribs.bar = 'bar';
-      return {
-        tagName: 'ul',
-        attribs: attribs
-      }
-    }}, allowedAttributes: { ul: ['bar', 'class'] } }), '<ul class="foo" bar="bar"><li>Hello world</li></ul>');
+    assert.equal(sanitizeHtml('<ol><li>Hello world</li></ol>', {
+      transformTags: {
+        ol: function(tagName, attribs) {
+          attribs.class = 'foo';
+          attribs.bar = 'bar';
+          return {
+            tagName: 'ul',
+            attribs: attribs
+          }
+        }
+      }, allowedAttributes: {ul: ['bar', 'class']}
+    }), '<ul class="foo" bar="bar"><li>Hello world</li></ul>');
   });
 
   it('should skip an empty link', function() {
-     assert.strictEqual(
-     sanitizeHtml('<p>This is <a href="http://www.linux.org"></a><br/>Linux</p>', {
-             exclusiveFilter: function (frame) {
-                 return frame.tag === 'a' && !frame.text.trim();
-             }
-         }),
-         '<p>This is <br />Linux</p>'
-        );
-    });
+    assert.strictEqual(
+      sanitizeHtml('<p>This is <a href="http://www.linux.org"></a><br/>Linux</p>', {
+        exclusiveFilter: function(frame) {
+          return frame.tag === 'a' && !frame.text.trim();
+        }
+      }),
+      '<p>This is <br />Linux</p>'
+    );
+  });
 
-    it("Should expose a node's inner text and inner HTML to the filter", function() {
-        assert.strictEqual(
-            sanitizeHtml('<p>12<a href="http://www.linux.org"><br/>3<br></a><span>4</span></p>', {
-                exclusiveFilter : function(frame) {
-                    if (frame.tag === 'p') {
-                        assert.strictEqual(frame.text, '124');
-                    } else if (frame.tag === 'a') {
-                        assert.strictEqual(frame.text, '3');
-                        return true;
-                    } else if (frame.tag === 'br') {
-                        assert.strictEqual(frame.text, '');
-                    } else {
-                        assert.fail('p, a, br', frame.tag);
-                    }
-                    return false;
-                }
-            }),
-            '<p>124</p>'
-        );
-    });
+  it("Should expose a node's inner text and inner HTML to the filter", function() {
+    assert.strictEqual(
+      sanitizeHtml('<p>12<a href="http://www.linux.org"><br/>3<br></a><span>4</span></p>', {
+        exclusiveFilter: function(frame) {
+          if (frame.tag === 'p') {
+            assert.strictEqual(frame.text, '124');
+          } else if (frame.tag === 'a') {
+            assert.strictEqual(frame.text, '3');
+            return true;
+          } else if (frame.tag === 'br') {
+            assert.strictEqual(frame.text, '');
+          } else {
+            assert.fail('p, a, br', frame.tag);
+          }
+          return false;
+        }
+      }),
+      '<p>124</p>'
+    );
+  });
 
   it('Should collapse nested empty elements', function() {
-        assert.strictEqual(
-            sanitizeHtml('<p><a href="http://www.linux.org"><br/></a></p>', {
-                    exclusiveFilter : function(frame) {
-                        return (frame.tag === 'a' || frame.tag === 'p' ) && !frame.text.trim();
-                    }
-                }),
-            ''
-        );
+    assert.strictEqual(
+      sanitizeHtml('<p><a href="http://www.linux.org"><br/></a></p>', {
+        exclusiveFilter: function(frame) {
+          return (frame.tag === 'a' || frame.tag === 'p' ) && !frame.text.trim();
+        }
+      }),
+      ''
+    );
   });
-  it('Exclusive filter should not affect elements which do not match the filter condition', function () {
-      assert.strictEqual(
-          sanitizeHtml('I love <a href="www.linux.org" target="_hplink">Linux</a> OS',
-              {
-                  exclusiveFilter: function (frame) {
-                      return (frame.tag === 'a') && !frame.text.trim();
-                  }
-              }),
-          'I love <a href="www.linux.org" target="_hplink">Linux</a> OS'
-      );
+  it('Exclusive filter should not affect elements which do not match the filter condition', function() {
+    assert.strictEqual(
+      sanitizeHtml('I love <a href="www.linux.org" target="_hplink">Linux</a> OS',
+        {
+          exclusiveFilter: function(frame) {
+            return (frame.tag === 'a') && !frame.text.trim();
+          }
+        }),
+      'I love <a href="www.linux.org" target="_hplink">Linux</a> OS'
+    );
   });
   it('should disallow data URLs with default allowedSchemes', function() {
     assert.equal(
@@ -159,7 +172,7 @@ describe('sanitizeHtml', function() {
         // teeny-tiny valid transparent GIF in a data URL
         '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />',
         {
-          allowedTags: [ 'img' ]
+          allowedTags: ['img']
         }
       ),
       '<img />'
@@ -171,11 +184,30 @@ describe('sanitizeHtml', function() {
         // teeny-tiny valid transparent GIF in a data URL
         '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />',
         {
-          allowedTags: [ 'img', 'p' ],
-          allowedSchemes: [ 'data', 'http' ]
+          allowedTags: ['img', 'p'],
+          allowedSchemes: {
+            sanitizeDefault: ['data', 'http']
+          }
         }
       ),
       '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />'
+    );
+  });
+  it('should allow defining schemes on a per-tag basis', function() {
+    assert.equal(
+      sanitizeHtml(
+        // teeny-tiny valid transparent GIF in a data URL
+        '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" /><a href="https://www.example.com"></a>',
+        {
+          allowedTags: ['img', 'a'],
+          allowedSchemes: {
+            img: [],
+            a: ['https'],
+            sanitizeDefault: ['http']
+          }
+        }
+      ),
+      '<img /><a href="https://www.example.com"></a>'
     );
   });
   it('should allow specific classes when whitelisted with allowedClasses', function() {
@@ -183,9 +215,9 @@ describe('sanitizeHtml', function() {
       sanitizeHtml(
         '<p class="nifty simple dippy">whee</p>',
         {
-          allowedTags: [ 'p' ],
+          allowedTags: ['p'],
           allowedClasses: {
-            p: [ 'nifty' ]
+            p: ['nifty']
           }
         }
       ),
@@ -197,9 +229,9 @@ describe('sanitizeHtml', function() {
       sanitizeHtml(
         '<p class="">whee</p>',
         {
-          allowedTags: [ 'p' ],
+          allowedTags: ['p'],
           allowedClasses: {
-            p: [ 'nifty' ]
+            p: ['nifty']
           }
         }
       ),
@@ -219,9 +251,9 @@ describe('sanitizeHtml', function() {
       sanitizeHtml(
         '<IMG SRC= onmouseover="alert(\'XSS\');">',
         {
-          allowedTags: [ 'img' ],
+          allowedTags: ['img'],
           allowedAttributes: {
-            img: [ 'src' ]
+            img: ['src']
           }
         }
       ),
@@ -236,12 +268,13 @@ describe('sanitizeHtml', function() {
       sanitizeHtml(
         '<a href="test.html">test</a>',
         {
-          allowedTags: [ 'a' ],
-          allowedAttributes: { a: ['href', 'target']},
+          allowedTags: ['a'],
+          allowedAttributes: {a: ['href', 'target']},
           transformTags: {
-            'a': function (tagName, attribs) {
-              if (!attribs.href)
+            'a': function(tagName, attribs) {
+              if (!attribs.href) {
                 return false;
+              }
               return {
                 tagName: tagName,
                 attribs: {
@@ -264,12 +297,13 @@ describe('sanitizeHtml', function() {
       sanitizeHtml(
         '<a href="test.html">blah</a>',
         {
-          allowedTags: [ 'a' ],
+          allowedTags: ['a'],
           allowedAttributes: {a: ['href', 'target']},
           transformTags: {
-            'a': function (tagName, attribs) {
-              if (!attribs.href)
+            'a': function(tagName, attribs) {
+              if (!attribs.href) {
                 return false;
+              }
               return {
                 tagName: tagName,
                 attribs: {
@@ -302,34 +336,34 @@ describe('sanitizeHtml', function() {
   it('should allow attributes to be specified as globs', function() {
     assert.equal(
       sanitizeHtml('<a data-target="#test" data-foo="hello">click me</a>', {
-        allowedTags: [ 'a' ],
-        allowedAttributes: { a: ['data-*'] }
+        allowedTags: ['a'],
+        allowedAttributes: {a: ['data-*']}
       }), '<a data-target="#test" data-foo="hello">click me</a>'
     );
     assert.equal(
       sanitizeHtml('<a data-target="#test" data-my-foo="hello">click me</a>', {
-        allowedTags: [ 'a' ],
-        allowedAttributes: { a: ['data-*-foo'] }
+        allowedTags: ['a'],
+        allowedAttributes: {a: ['data-*-foo']}
       }), '<a data-my-foo="hello">click me</a>'
     );
   });
   it('should quote regex chars in attributes specified as globs', function() {
     assert.equal(
       sanitizeHtml('<a data-b.c="#test" data-bcc="remove this">click me</a>', {
-        allowedTags: [ 'a' ],
-        allowedAttributes: { a: ['data-b.*'] }
+        allowedTags: ['a'],
+        allowedAttributes: {a: ['data-b.*']}
       }), '<a data-b.c="#test">click me</a>'
     );
   });
   it('should not escape inner content from non-text tags (when allowed)', function() {
     assert.equal(
       sanitizeHtml('<div>"normal text"</div><script>"this is code"</script>', {
-        allowedTags: [ 'script' ]
+        allowedTags: ['script']
       }), '&quot;normal text&quot;<script>"this is code"</script>'
     );
     assert.equal(
       sanitizeHtml('<div>"normal text"</div><style>body { background-image: url("image.test"); }</style>', {
-        allowedTags: [ 'style' ]
+        allowedTags: ['style']
       }), '&quot;normal text&quot;<style>body { background-image: url("image.test"); }</style>'
     );
   });


### PR DESCRIPTION
Add the ability to create allowable schemes on a per-tag basis. Is backwards-compatible and includes unit tests. Apparently my editor reformatted all the whitespace without me realizing, let me know if you want a pull request with no whitespace changes :smile: 

Per-tag basis overrides anything set in the default. So if you have something set in the default ("https" for example) but then set the allowable schemes to [] for a tag, nothing will be allowed. Example from the unit test:

```javascript
allowedSchemes: ['http'],
  allowedSchemesPerTag: {
  img: [],
  a: ['https']
}
```