### PR TITLE
Removed lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,9 @@
   "author": "P'unk Avenue LLC",
   "license": "MIT",
   "dependencies": {
+    "array-includes": "^2.0.0",
     "htmlparser2": "3.8.x",
-    "lodash": "2.4.x",
-    "regexp-quote": "0.0.0"
+    "regexp-quote": "0.0.0",
+    "xtend": "^4.0.0"
   }
 }


### PR DESCRIPTION
**Tests pass**

- Removed `lodash` dependency.
- Added [`array-includes`](https://npmjs.com/package/array-includes) dependency. ([`Array.prototype.includes`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes) polyfill.)
- Added [`xtend`](https://npmjs.com/package/xtend) dependency. (Replaces `_.defaults`)

I also shortened a few verbose statements:

```js
// was
var whateverMap;
allowedTagsMap = {};
_.each(options.whatever, function(tag) {
  whateverMap[tag] = true;
});

// ... later ...

if (whateverMap && !_.has(whateverMap, name)) {
```

```js
// is now
if (options.whatever && !options.whatever.includes(name)) {
```