### PR TITLE
Added the ability to transform every element using '*'

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,11 +73,18 @@ function sanitizeHtml(html, options, _recursing) {
   });
 
   var transformTagsMap = {};
-  each(options.transformTags, function(transform, tag){
+  var transformTagsAll;
+  each(options.transformTags, function(transform, tag) {
+    var transFun;
     if (typeof transform === 'function') {
-      transformTagsMap[tag] = transform;
+      transFun = transform;
     } else if (typeof transform === "string") {
-      transformTagsMap[tag] = sanitizeHtml.simpleTransform(transform);
+      transFun = sanitizeHtml.simpleTransform(transform);
+    }
+    if (tag === '*') {
+      transformTagsAll = transFun;
+    } else {
+      transformTagsMap[tag] = transFun;
     }
   });
 
@@ -92,8 +99,18 @@ function sanitizeHtml(html, options, _recursing) {
       stack.push(frame);
 
       var skip = false;
+      var transformedTag;
       if (transformTagsMap[name]) {
-        var transformedTag = transformTagsMap[name](name, attribs);
+        transformedTag = transformTagsMap[name](name, attribs);
+
+        frame.attribs = attribs = transformedTag.attribs;
+        if (name !== transformedTag.tagName) {
+          frame.name = name = transformedTag.tagName;
+          transformMap[depth] = transformedTag.tagName;
+        }
+      }
+      if (transformTagsAll) {
+        transformedTag = transformTagsAll(name, attribs);
 
         frame.attribs = attribs = transformedTag.attribs;
         if (name !== transformedTag.tagName) {

--- a/test/test.js
+++ b/test/test.js
@@ -319,6 +319,28 @@ describe('sanitizeHtml', function() {
       ''
     );
   });
+  it('should allow transform on all tags using \'*\'', function () {
+    assert.equal(
+      sanitizeHtml(
+        '<p>Text</p>',
+        {
+          allowedTags: [ 'p' ],
+          allowedAttributes: {p: ['style']},
+          transformTags: {
+            '*': function (tagName, attribs) {
+              return {
+                tagName: tagName,
+                attribs: {
+                  style: 'text-align: center;'
+                }
+              };
+            }
+          }
+        }
+      ),
+      '<p style="text-align: center;">Text</p>'
+    );
+  });
   it('should not be faked out by double <', function() {
     assert.equal(
       sanitizeHtml('<<img src="javascript:evil"/>img src="javascript:evil"/>'


### PR DESCRIPTION
The use case for this is if you want to validate a certain attribute on every element. For example, my usecase: running a CSS sanitize on every element's style attribute.