### PR TITLE
Allow setting of htmlparser2 options

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ allowedAttributes: {
   a: [ 'href', 'data-*' ]
 }
 ```
+### htmlparser2 Options
+
+`santizeHtml` is built on `htmlparser2`. By default the only option passed down is `decodeEntities: true` You can set the options to pass by using the parser option.
+
+```javascript
+clean = sanitizeHtml(dirty, {
+    allowedTags: ['a'],
+    parser: {
+        lowerCaseTags: true
+    }
+});
+```
+See the [htmlparser2 wiki] (https://github.com/fb55/htmlparser2/wiki/Parser-options) for the full list of possible options.
 
 ### Transformations
 

--- a/index.js
+++ b/index.js
@@ -34,8 +34,14 @@ function sanitizeHtml(html, options, _recursing) {
 
   if (!options) {
     options = sanitizeHtml.defaults;
+    options.parser = htmlParserDefaults;
   } else {
     options = extend(sanitizeHtml.defaults, options);
+    if (options.parser) {
+      options.parser = extend(htmlParserDefaults, options.parser);
+    } else {
+      options.parser = htmlParserDefaults;
+    }
   }
   // Tags that contain something other than HTML, or where discarding
   // the text when the tag is disallowed makes sense for other reasons.
@@ -231,8 +237,7 @@ function sanitizeHtml(html, options, _recursing) {
 
       result += "</" + name + ">";
     }
-  }, { decodeEntities: true });
-
+  }, options.parser);
   parser.write(html);
   parser.end();
 
@@ -284,6 +289,9 @@ function sanitizeHtml(html, options, _recursing) {
 // Defaults are accessible to you so that you can use them as a starting point
 // programmatically if you wish
 
+var htmlParserDefaults = {
+  decodeEntities: true
+};
 sanitizeHtml.defaults = {
   allowedTags: [ 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol',
     'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'hr', 'br', 'div',

--- a/test/test.js
+++ b/test/test.js
@@ -425,4 +425,23 @@ describe('sanitizeHtml', function() {
       }), '&quot;normal text&quot;'
     );
   });
+  it('should respect htmlparser2 options when passed in', function() {
+    assert.equal(
+      sanitizeHtml("<Archer><Sterling>I am</Sterling></Archer>", {
+        allowedTags: false,
+        allowedAttributes: false,
+      }),
+      "<archer><sterling>I am</sterling></archer>"
+    );
+    assert.equal(
+      sanitizeHtml("<Archer><Sterling>I am</Sterling></Archer>", {
+        allowedTags: false,
+        allowedAttributes: false,
+        parser: {
+          lowerCaseTags: false
+        }
+      }),
+      "<Archer><Sterling>I am</Sterling></Archer>"
+    );
+  });
 });


### PR DESCRIPTION
Simple addition that allows the user to pass in options to the htmlparser2