### PR TITLE
Feature: adding option to allow list of attributes to any tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ allowedAttributes: {
   a: [ 'href', 'data-*' ]
 }
 ```
+
+Also you can use the `*` as name for a tag, to allow listed attributes to be valid for any tag:
+
+```javascript
+allowedAttributes: {
+  '*': [ 'href', 'align', 'alt', 'center', 'bgcolor' ]
+}
+```
+
 ### htmlparser2 Options
 
 `santizeHtml` is built on `htmlparser2`. By default the only option passed down is `decodeEntities: true` You can set the options to pass by using the parser option.

--- a/index.js
+++ b/index.js
@@ -144,10 +144,13 @@ function sanitizeHtml(html, options, _recursing) {
         return;
       }
       result += '<' + name;
-      if (!allowedAttributesMap || allowedAttributesMap[name]) {
+      if (!allowedAttributesMap || allowedAttributesMap[name] || allowedAttributesMap['*']) {
         each(attribs, function(value, a) {
-          if (!allowedAttributesMap || allowedAttributesMap[name].indexOf(a) !== -1 ||
-              (allowedAttributesGlobMap[name] && allowedAttributesGlobMap[name].test(a))) {
+          if (!allowedAttributesMap ||
+              (allowedAttributesMap[name] && allowedAttributesMap['*'].indexOf(a) !== -1 ) ||
+              (allowedAttributesMap['*'] && allowedAttributesMap['*'].indexOf(a) !== -1 ) ||
+              (allowedAttributesGlobMap[name] && allowedAttributesGlobMap[name].test(a)) ||
+              (allowedAttributesGlobMap['*'] && allowedAttributesGlobMap['*'].test(a))) {
             if ((a === 'href') || (a === 'src')) {
               if (naughtyHref(name, value)) {
                 delete frame.attribs[a];

--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ function sanitizeHtml(html, options, _recursing) {
       if (!allowedAttributesMap || allowedAttributesMap[name] || allowedAttributesMap['*']) {
         each(attribs, function(value, a) {
           if (!allowedAttributesMap ||
-              (allowedAttributesMap[name] && allowedAttributesMap['*'].indexOf(a) !== -1 ) ||
+              (allowedAttributesMap[name] && allowedAttributesMap[name].indexOf(a) !== -1 ) ||
               (allowedAttributesMap['*'] && allowedAttributesMap['*'].indexOf(a) !== -1 ) ||
               (allowedAttributesGlobMap[name] && allowedAttributesGlobMap[name].test(a)) ||
               (allowedAttributesGlobMap['*'] && allowedAttributesGlobMap['*'].test(a))) {

--- a/test/test.js
+++ b/test/test.js
@@ -292,6 +292,20 @@ describe('sanitizeHtml', function() {
       '<img src="onmouseover=&quot;alert(\'XSS\');&quot;" />'
     );
   });
+  it('should allow only whitelisted attributes, but to any tags, if tag is declared as  "*"', function() {
+    assert.equal(
+        sanitizeHtml(
+            '<table bgcolor="1" align="left" notlisted="0"><img src="1.gif" align="center" alt="not listed too"/></table>',
+            {
+              allowedTags: [ 'table', 'img' ],
+              allowedAttributes: {
+                '*': [ 'bgcolor', 'align', 'src' ]
+              }
+            }
+        ),
+        '<table bgcolor="1" align="left"><img src="1.gif" align="center" /></table>'
+    );
+  });
   it('should not filter if exclusive filter does not match after transforming tags', function() {
     assert.equal(
       sanitizeHtml(


### PR DESCRIPTION
When I used sanitizer with whitelist option, I run into situation, when i wanted to allow a LOT of tags, and a LOT of attributes. But it was a pain to describe attributes for each of tags. So i made small changes, to allow some attributes to be allowed on any tag, declaring them like:

```javascript
allowedAttributes: {
  '*': [ 'href', 'align', 'alt', 'center', 'bgcolor' ]
}
```
It works, and it's handy for me. I am reconsidering to make some default whitelists too, because default whitelist is a way too restricted for HTML editors, for example.