### PR TITLE
Regression on last update when nesting tags

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -46,6 +46,9 @@ describe('sanitizeHtml', function() {
   it('should drop the content of textarea elements', function() {
     assert.equal(sanitizeHtml('<textarea>Nifty</textarea><p>Paragraph</p>'), '<p>Paragraph</p>');
   });
+  it('should drop the content of textarea elements but keep the closing parent tag, when nested', function() {
+    assert.equal(sanitizeHtml('<p>Paragraph<textarea>Nifty</textarea></p>'), '<p>Paragraph</p>');
+  });
   it('should retain the content of fibble elements by default', function() {
     assert.equal(sanitizeHtml('<fibble>Nifty</fibble><p>Paragraph</p>'), 'Nifty<p>Paragraph</p>');
   });


### PR DESCRIPTION
Hello!
We found a regression with the last update, I could replicate it with this test, but I'm not able to fix it in the code.

Can you please have a look?

Thanks!

```
  57 passing (78ms)
  1 failing

  1) sanitizeHtml should drop the content of textarea elements but keep the closing parent tag, when nested:

      AssertionError: '<p>Paragraph' == '<p>Paragraph</p>'
      + expected - actual

      -<p>Paragraph
      +<p>Paragraph</p>

      at Context.<anonymous> (test/test.js:50:12)
```