### PR TITLE
OWASP: Grave accent obfuscation

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,6 +276,9 @@ function sanitizeHtml(html, options, _recursing) {
     // number of situations. Start reading here:
     // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#Embedded_tab
     href = href.replace(/[\x00-\x20]+/g, '');
+    // Clobber grave accent
+    // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#Grave_accent_obfuscation
+    href = href.replace(/`/, '');
     // Clobber any comments in URLs, which the browser might
     // interpret inside an XML data island, allowing
     // a javascript: URL to be snuck through

--- a/index.js
+++ b/index.js
@@ -278,7 +278,7 @@ function sanitizeHtml(html, options, _recursing) {
     href = href.replace(/[\x00-\x20]+/g, '');
     // Clobber grave accent
     // https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#Grave_accent_obfuscation
-    href = href.replace(/`/, '');
+    href = href.replace(/`/g, '');
     // Clobber any comments in URLs, which the browser might
     // interpret inside an XML data island, allowing
     // a javascript: URL to be snuck through

--- a/test/test.js
+++ b/test/test.js
@@ -222,6 +222,25 @@ describe('sanitizeHtml', function() {
       '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" />'
     );
   });
+  it('should prevent from OWASP grave accent obfuscation', function() {
+    assert.equal(
+      sanitizeHtml(
+      '<img SRC=`javascript:alert("RSnake says, XSS")`>',
+        {
+          allowedTags: ['img']
+        }
+      ),
+      '<img />'
+    );
+  });
+  it('should allow grave accents in normal text (for i18n)', function() {
+    assert.equal(
+      sanitizeHtml(
+        '<p>`test`</p>'
+      ),
+      '<p>`test`</p>'
+    );
+  });
   it('should allow specific classes when whitelisted with allowedClasses', function() {
     assert.equal(
       sanitizeHtml(


### PR DESCRIPTION
Attempts to solve the grave accent obfuscation XSS attack point (https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#Grave_accent_obfuscation) by just killing grave accents in naughty-href. Not sure if it's the best strategy but seems to fix the problem and pass old tests.