### PR TITLE
Support adding new text to an element that has no initial text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,29 @@ simpleTransform(newTag, newAttributes, shouldMerge)
 
 The last parameter (`shouldMerge`) is set to `true` by default. When `true`, `simpleTransform` will merge the current attributes with the new ones (`newAttributes`). When `false`, all existing attributes are discarded.
 
+You can also add or modify the text contents of a tag:
+
+```js
+clean = sanitizeHtml(dirty, {
+  transformTags: {
+    'a': function(tagName, attribs) {
+        return {
+            tagName: 'a',
+            text: 'Some text'
+        };
+    }
+  }
+});
+```
+For example, you could transform a link element with missing anchor text:
+```js
+<a href="http://somelink.com"></a>
+```
+To a link with anchor text:
+```js
+<a href="http://somelink.com">Some text</a>
+```
+
 ### Filters
 
 You can provide a filter function to remove unwanted tags. Let's suppose we need to remove empty `a` tags like:
@@ -396,5 +419,3 @@ We're rocking our tests and have been working great in production for months, so
 Feel free to open issues on [github](http://github.com/punkave/sanitize-html).
 
 <a href="http://punkave.com/"><img src="https://raw.github.com/punkave/sanitize-html/master/logos/logo-box-builtby.png" /></a>
-
-

--- a/index.js
+++ b/index.js
@@ -113,6 +113,7 @@ function sanitizeHtml(html, options, _recursing) {
       stack.push(frame);
 
       var skip = false;
+      var hasText = frame.text ? true : false;
       var transformedTag;
       if (transformTagsMap[name]) {
         transformedTag = transformTagsMap[name](name, attribs);
@@ -185,6 +186,9 @@ function sanitizeHtml(html, options, _recursing) {
         result += " />";
       } else {
         result += ">";
+        if (frame.innerText && !hasText && !options.textFilter) {
+          result += frame.innerText;
+        }
       }
     },
     ontext: function(text) {

--- a/test/test.js
+++ b/test/test.js
@@ -154,6 +154,15 @@ describe('sanitizeHtml', function() {
     }}}), '<a href="http://somelink">some new text</a>');
   });
 
+  it('should preserve text when initially set and replace attributes when they are changed by transforming function', function () {
+    assert.equal(sanitizeHtml('<a href="http://somelink">some initial text</a>', { transformTags: {a: function (tagName, attribs) {
+      return {
+        tagName: tagName,
+        attribs: attribs
+      }
+    }}}), '<a href="http://somelink">some initial text</a>');
+  });
+
   it('should skip an empty link', function() {
      assert.strictEqual(
      sanitizeHtml('<p>This is <a href="http://www.linux.org"></a><br/>Linux</p>', {

--- a/test/test.js
+++ b/test/test.js
@@ -144,6 +144,16 @@ describe('sanitizeHtml', function() {
     }}), '<a href="http://somelink">some_text_need&quot;to&lt;be&gt;filtered</a>');
   });
 
+  it('should add new text when not initially set and replace attributes when they are changed by transforming function', function () {
+    assert.equal(sanitizeHtml('<a href="http://somelink"></a>', { transformTags: {a: function (tagName, attribs) {
+      return {
+        tagName: tagName,
+        attribs: attribs,
+        text: 'some new text'
+      }
+    }}}), '<a href="http://somelink">some new text</a>');
+  });
+
   it('should skip an empty link', function() {
      assert.strictEqual(
      sanitizeHtml('<p>This is <a href="http://www.linux.org"></a><br/>Linux</p>', {


### PR DESCRIPTION
This adds support for adding new text (innerText) to an element that has no text initially set.

For example, this element:

    <a href="http://somelink.com"></a>

Can now be transformed  to:

    <a href="http://somelink.com">some text</a>


Amazing module btw, I'm finding this indispensable for retooling existing pages to AMP markup.  With this PR, I can do something like this as a fallback for unsupported/illegal elements:

    <iframe src="http://somelink.com"></iframe>

Transforms to:
    
    <a href="http://somelink.com">some text</a>
