### PR TITLE
Allow for filtering of CSS Styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,29 @@ clean = sanitizeHtml(dirty, {
 });
 ```
 
+### Allowed CSS Styles
+
+If you wish to allow specific CSS _styles_ on a particular element, you can do that with the `allowedStyles` option.
+Any other CSS classes are discarded.
+
+This implies that the `style` attribute is allowed on that element
+
+```javascript
+clean = sanitizeHtml(dirty, {
+        allowedTags: ['p'],
+        allowedAttributes: {
+          'p': ["style"],
+        },
+        allowedStyles: {
+          '*': {
+            'color': '*',
+            'text-align': ['left','right','center','justify','initial','inherit'],
+            'font-size': '*'
+          }
+        }
+      });
+```
+
 ### Allowed URL schemes
 
 By default we allow the following URL schemes in cases where `href`, `src`, etc. are allowed:

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var htmlparser = require('htmlparser2');
 var extend = require('xtend');
 var quoteRegexp = require('regexp-quote');
-var caja = require('html-css-sanitizer');
 var css = require('css');
 
 function each(obj, cb) {

--- a/index.js
+++ b/index.js
@@ -178,6 +178,10 @@ function sanitizeHtml(html, options, _recursing) {
                 var ast = css.parse(name + " {" + value + "}");
                 var filteredAST = filterCss(ast);
                 value = css.stringify(filteredAST, {compress: true}).substr(name.length + 1).slice(0, -1);
+                if(value.length === 0) {
+                  delete frame.attribs[a];
+                  return;
+                }
               } catch (e) {
                 delete frame.attribs[a];
                 return;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "P'unk Avenue LLC",
   "license": "MIT",
   "dependencies": {
+    "css": "^2.2.1",
     "htmlparser2": "^3.9.0",
     "regexp-quote": "0.0.0",
     "xtend": "^4.0.0"

--- a/test/test.js
+++ b/test/test.js
@@ -396,7 +396,7 @@ describe('sanitizeHtml', function() {
           }
         }
       ),
-      '<p style="text-align: center;">Text</p>'
+      '<p style="text-align:center;">Text</p>'
     );
   });
   it('should not be faked out by double <', function() {
@@ -472,5 +472,27 @@ describe('sanitizeHtml', function() {
       }),
       "<Archer><Sterling>I am</Sterling></Archer>"
     );
+  });
+  it('should sanitize styles correctly', function() {
+    var sanitizeString = '<p dir="ltr"><strong>beste</strong><em>testestes</em><s>testestset</s><u>testestest</u></p><ul dir="ltr"> <li><u>test</u></li></ul><blockquote dir="ltr"> <ol> <li><u>​test</u></li><li><u>test</u></li><li style="text-align: right;"><u>test</u></li><li style="text-align: justify;"><u>test</u></li></ol> <p><u><span style="color:#00FF00;">test</span></u></p><p><span style="color:#00FF00"><span style="font-size:36px;">TESTETESTESTES</span></span></p></blockquote>';
+    var expected = '<p dir="ltr"><strong>beste</strong><em>testestes</em><s>testestset</s><u>testestest</u></p><ul dir="ltr"> <li><u>test</u></li></ul><blockquote dir="ltr"> <ol> <li><u>​test</u></li><li><u>test</u></li><li style="text-align: right;"><u>test</u></li><li style="text-align: justify;"><u>test</u></li></ol> <p><u><span style="color:#00FF00;">test</span></u></p><p><span style="color:#00FF00;"><span style="font-size:36px;">TESTETESTESTES</span></span></p></blockquote>';
+    assert.equal(
+      sanitizeHtml(sanitizeString, {
+        allowedTags: false,
+        allowedAttributes: {
+          '*': ["dir"],
+          p: ["dir", "style"],
+          li: ["style"],
+          span: ["style"]
+        },
+        allowedStyles: {
+          '*': {
+            'color': '*',
+            'text-align': ['left','right','center','justify','initial','inherit'],
+            'font-size': '*'
+          }
+        }
+      }).replace(/ /g,''), expected.replace(/ /g,'')
+    )
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -503,5 +503,39 @@ describe('sanitizeHtml', function() {
       }),
       "<span></span>"
     );
+  });
+  it('Should remote invalid styles', function() {
+    assert.equal(
+      sanitizeHtml("<span style='color: blue; text-align: justify'></span>", {
+        allowedTags: false,
+        allowedAttributes: {
+          "span": ["style"]
+        },
+        allowedStyles: {
+          'span': {
+            "color": "blue",
+            "text-align": ['left']
+          }
+        }
+      }), '<span style="color:blue;"></span>'
+    );
+  });
+  it('Should allow a specific style from global', function() {
+    assert.equal(
+      sanitizeHtml("<span style='color: yellow;'></span>", {
+        allowedTags: false,
+        allowedAttributes: {
+          "span": ["style"]
+        },
+        allowedStyles: {
+          '*': {
+            "color": ["yellow"]
+          },
+          'span': {
+            "color": ["green"]
+          }
+        }
+      }), '<span style="color:yellow;"></span>'
+    );
   })
 });

--- a/test/test.js
+++ b/test/test.js
@@ -495,4 +495,13 @@ describe('sanitizeHtml', function() {
       }).replace(/ /g,''), expected.replace(/ /g,'')
     )
   });
+  it('Should remove empty style tags', function() {
+    assert.equal(
+      sanitizeHtml("<span style=''></span>", {
+        allowedTags: false,
+        allowedAttributes: false
+      }),
+      "<span></span>"
+    );
+  })
 });


### PR DESCRIPTION
Adds the ability to parse _inline_ css and decide whether or not to include it based off of the tag names. Uses the css library to parse out the inline css, filters it, then stringify's the CSS and re-inserts it, meaning that some whitespace or semicolons could be lost on the reparsing.

Definitely needs some code review.
