### PR TITLE
Npm run build / npm run minify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 npm-debug.log
 *.DS_Store
 node_modules
+dist
 # We do not commit CSS, only LESS
 public/css/*.css

--- a/README.md
+++ b/README.md
@@ -22,6 +22,39 @@ HTML comments are not preserved.
 
 ## How to use
 
+### Browser 
+
+* Clone repository
+* Run npm install and build / minify:
+
+```bash
+npm install
+npm run minify
+```
+
+You'll find the minified and unminified versions of sanitize-html (with all its dependencies included) in the dist/ directory.
+
+Use it in the browser:
+
+```html
+<html>
+    <body>
+        <script type="text/javascript"  src="dist/sanitize-html.js"></script>
+        <script type="text/javascript" src="demo.js"></script>
+    </body>
+</html>
+```
+
+```javascript
+var html = "<strong>hello world</strong>";
+console.log(sanitizeHtml(html));
+console.log(sanitizeHtml("<img src=x onerror=alert('img') />"));
+console.log(sanitizeHtml("console.log('hello world')"));
+console.log(sanitizeHtml("<script>alert('hello world')</script>"));
+```
+
+### Node (Recommended)
+
 Install module from console:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Clean up user-submitted HTML, preserving whitelisted elements and whitelisted attributes on a per-element basis",
   "main": "index.js",
   "scripts": {
-    "build": "cp index.js dist/sanitize-html.js && browserify index.js > dist/sanitize-html.min.js",
+    "build": "browserify index.js > dist/sanitize-html.js --standalone 'sanitizeHtml'",
+    "minify": "npm run build && uglifyjs dist/sanitize-html.js > dist/sanitize-html.min.js",
     "test": "mocha test/test.js",
     "prebuild": "npm run test && rm -rf dist && mkdir dist"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Clean up user-submitted HTML, preserving whitelisted elements and whitelisted attributes on a per-element basis",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/test.js"
+    "build": "cp index.js dist/sanitize-html.js && browserify index.js > dist/sanitize-html.min.js",
+    "test": "mocha test/test.js",
+    "prebuild": "npm run test && rm -rf dist && mkdir dist"
   },
   "repository": {
     "type": "git",
@@ -26,6 +28,8 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "mocha": "^2.5.3"
+    "browserify": "^13.0.1",
+    "mocha": "^2.5.3",
+    "uglify-js": "^2.6.2"
   }
 }


### PR DESCRIPTION
discussion: #112 (https://github.com/punkave/sanitize-html/issues/112)

Build commands for creating packaged sanitize-html JS files for use in the front end.

`npm run build`: runs unit tests and creates an unminified browserify-ied sanitize-html.js

`npm run minify`: runs unit tests, build, and uses uglify to minify the sanitize-html.js file as sanitize-html.min.js

`npm run prebuild`: execute unit tests and create a fresh dist directory

For npm commands, can we run mkdir on a Windows box? Does npm abstract this away? Or are they just shell commands?