### PR TITLE
Add option to allow empty URL schemes

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,8 +296,8 @@ function sanitizeHtml(html, options, _recursing) {
     // Case insensitive so we don't get faked out by JAVASCRIPT #1
     var matches = href.match(/^([a-zA-Z]+)\:/);
     if (!matches) {
-      // No scheme = no way to inject js (right?)
-      return false;
+      // No scheme, "//some.domain.co/nasty" or "some.domain.co/nasty"
+      return options.allowProtocolRelative;
     }
     var scheme = matches[1].toLowerCase();
 
@@ -340,7 +340,8 @@ sanitizeHtml.defaults = {
   selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta' ],
   // URL schemes we permit
   allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
-  allowedSchemesByTag: {}
+  allowedSchemesByTag: {},
+  allowProtocolRelative: true
 };
 
 sanitizeHtml.simpleTransform = function(newTagName, newAttribs, merge) {

--- a/index.js
+++ b/index.js
@@ -301,8 +301,8 @@ function sanitizeHtml(html, options, _recursing) {
         return options.allowProtocolRelative;
       }
 
-      // No scheme: "some.evil.com/nasty"
-      return true;
+      // No scheme
+      return false;
     }
     var scheme = matches[1].toLowerCase();
 

--- a/index.js
+++ b/index.js
@@ -296,8 +296,13 @@ function sanitizeHtml(html, options, _recursing) {
     // Case insensitive so we don't get faked out by JAVASCRIPT #1
     var matches = href.match(/^([a-zA-Z]+)\:/);
     if (!matches) {
-      // No scheme, "//some.domain.co/nasty" or "some.domain.co/nasty"
-      return options.allowProtocolRelative;
+      // Protocol-relative URL: "//some.evil.com/nasty"
+      if (href.match(/^\/\//)) {
+        return options.allowProtocolRelative;
+      }
+
+      // No scheme: "some.evil.com/nasty"
+      return true;
     }
     var scheme = matches[1].toLowerCase();
 


### PR DESCRIPTION
Set to true by default, this can be set to false to avoid //evil.com/nasty or evil.com/nasty being allowed as hrefs.