### PR TITLE
Reject malformed HTML attribute names.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -570,4 +570,13 @@ describe('sanitizeHtml', function() {
       '<img src="fallback.jpg" srcset="foo.jpg 100w 2x, bar.jpg 200w 1x" />'
     );
   });
+  it('drop attribute names with meta-characters', function() {
+    assert.equal(
+      sanitizeHtml('<span data-<script>alert(1)//>', {
+        allowedTags: ['span'],
+        allowedAttributes: { 'span': ['data-*'] }
+      }),
+      '<span>alert(1)//&gt;</span>'
+    );
+  });
 });


### PR DESCRIPTION
This rejects all names that would trigger parse errors in a validating
HTML parser which turns out to be a pretty small set.

This should make it harder to cause a parser of the sanitized HTML
to incorrectly find an attribute or tag boundary inside an attribute
name.