### PR TITLE
CSS Sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ HTML comments are not preserved.
 
 ## How to use
 
-### Browser 
+### Browser
 
 *Think first: why do you want to use it in the browser?* Remember, *servers must never trust browsers.* You can't sanitize HTML for saving on the server anywhere else but on the server.
 
@@ -312,7 +312,7 @@ clean = sanitizeHtml(dirty, {
 
 ### Allowed CSS Styles
 
-If you wish to allow specific CSS _styles_ on a particular element, you can do that with the `allowedStyles` option.
+If you wish to allow specific CSS _styles_ on a particular element, you can do that with the `allowedStyles` option. Simply declare your desired attributes as regular expression options within an array for the given attribute. Specific elements will inherit whitelisted attributes from the global (\*) attribute.
 Any other CSS classes are discarded.
 
 This implies that the `style` attribute is allowed on that element
@@ -325,9 +325,14 @@ clean = sanitizeHtml(dirty, {
         },
         allowedStyles: {
           '*': {
-            'color': '*',
-            'text-align': ['left','right','center','justify','initial','inherit'],
-            'font-size': '*'
+            // Match HEX and RGB
+            'color': [/\#(0x)?[0-9a-f]+/i, /rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/],
+            'text-align': [/left/, /right/, /center/],
+            // Match any number with px, em, or %
+            'font-size': [/\d+[px|em|\%]/]
+          },
+          'p': {
+            'font-size': [/\d+rem/]
           }
         }
       });

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ clean = sanitizeHtml(dirty, {
             'color': [/\#(0x)?[0-9a-f]+/i, /rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/],
             'text-align': [/left/, /right/, /center/],
             // Match any number with px, em, or %
-            'font-size': [/\d+[px|em|\%]/]
+            'font-size': [/^\d+$[px|em|\%]/]
           },
           'p': {
             'font-size': [/\d+rem/]

--- a/README.md
+++ b/README.md
@@ -249,6 +249,29 @@ clean = sanitizeHtml(dirty, {
 });
 ```
 
+### Allowed CSS Styles
+
+If you wish to allow specific CSS _styles_ on a particular element, you can do that with the `allowedStyles` option.
+Any other CSS classes are discarded.
+
+This implies that the `style` attribute is allowed on that element
+
+```javascript
+clean = sanitizeHtml(dirty, {
+        allowedTags: ['p'],
+        allowedAttributes: {
+          'p': ["style"],
+        },
+        allowedStyles: {
+          '*': {
+            'color': '*',
+            'text-align': ['left','right','center','justify','initial','inherit'],
+            'font-size': '*'
+          }
+        }
+      });
+```
+
 ### Allowed URL schemes
 
 By default we allow the following URL schemes in cases where `href`, `src`, etc. are allowed:

--- a/README.md
+++ b/README.md
@@ -326,13 +326,13 @@ clean = sanitizeHtml(dirty, {
         allowedStyles: {
           '*': {
             // Match HEX and RGB
-            'color': [/\#(0x)?[0-9a-f]+/i, /rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/],
-            'text-align': [/left/, /right/, /center/],
+            'color': [/^\#(0x)?[0-9a-f]+$/i, /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/],
+            'text-align': [/^left$/, /^right$/, /^center$/],
             // Match any number with px, em, or %
-            'font-size': [/^\d+$[px|em|\%]/]
+            'font-size': [/^\d+$[px|em|\%]$/]
           },
           'p': {
-            'font-size': [/\d+rem/]
+            'font-size': [/^\d+rem$/]
           }
         }
       });

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var htmlparser = require('htmlparser2');
 var extend = require('xtend');
 var quoteRegexp = require('regexp-quote');
-var caja = require('html-css-sanitizer');
 var css = require('css');
 
 function each(obj, cb) {

--- a/index.js
+++ b/index.js
@@ -178,6 +178,10 @@ function sanitizeHtml(html, options, _recursing) {
                 var ast = css.parse(name + " {" + value + "}");
                 var filteredAST = filterCss(ast);
                 value = css.stringify(filteredAST, {compress: true}).substr(name.length + 1).slice(0, -1);
+                if(value.length === 0) {
+                  delete frame.attribs[a];
+                  return;
+                }
               } catch (e) {
                 delete frame.attribs[a];
                 return;

--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@ var htmlparser = require('htmlparser2');
 var extend = require('xtend');
 var quoteRegexp = require('lodash.escaperegexp');
 var cloneDeep = require('lodash.clonedeep')
+var isArray = require('lodash.isarray');
+var mergeWith = require('lodash.mergewith');
 var srcset = require('srcset');
 var css = require('css');
 
@@ -402,51 +404,63 @@ function sanitizeHtml(html, options, _recursing) {
    * @param {object} allowedStyles - Keys are properties (i.e color), value is list of permitted regex rules (i.e /green/i).
    * @return {object}                    - Abstract Syntax Tree with filtered style attributes.
    */
-function filterCss(abstractSyntaxTree, allowedStyles) {
-  'use strict';
-  if (!allowedStyles) {
-    return abstractSyntaxTree;
-  }
+  function filterCss(abstractSyntaxTree, allowedStyles) {
+    var selectedRule;
 
-  var filteredAST = cloneDeep(abstractSyntaxTree);
-  // There should only be one element in the abstractSyntaxTree array based on how we set it up
-  var astRules = abstractSyntaxTree.stylesheet.rules[0];
-  var selectedRule = allowedStyles[astRules.selectors[0]] || allowedStyles['*'];
-  // Check if selector is in our allowed styles
+    if (!allowedStyles) {
+      return abstractSyntaxTree;
+    }
 
-  if (selectedRule) {
-    /**
-         * Filters the existing attributes for the given property. Discards any attributes
-         * which don't match the whitelist.
-         *
-         * @param  {object} attributeObject - Object representing the current css property.
-         * @property {string} type          - Typically 'declaration'.
-         * @property {string} property      - The CSS property, i.e 'color'.
-         * @property {string} value         - The corresponding value to the css property, i.e 'red'.
-         * @return {abstractSyntaxTree}     - Object representation of attributes and values.
-         */
-    var filteredDeclarations = astRules.declarations.reduce(function(
-      allowedDeclarationsList,
-      attributeObject
-    ) {
-      // If this property is whitelisted...
-      if (selectedRule.hasOwnProperty(attributeObject.property)) {
-        var matchesRegex = selectedRule[attributeObject.property].some(function(regularExpression) {
-          return regularExpression.test(attributeObject.value);
-        });
+    var filteredAST = cloneDeep(abstractSyntaxTree);
+    // There should only be one element in the abstractSyntaxTree array based on how we set it up
+    var astRules = abstractSyntaxTree.stylesheet.rules[0];
 
-        if (matchesRegex) {
-          allowedDeclarationsList.push(attributeObject);
+    // Merge global and specific styles, keeps original state.
+    if (allowedStyles[astRules.selectors[0]] && allowedStyles['*']) {
+      selectedRule = mergeWith(
+        cloneDeep(allowedStyles[astRules.selectors[0]]),
+        allowedStyles['*'],
+        function(objValue, srcValue) {
+          if (isArray(objValue)) {
+            return objValue.concat(srcValue);
+          }
         }
-        return allowedDeclarationsList;
-      }
-    }, []);
+      );
+    } else {
+      selectedRule = allowedStyles[astRules.selectors[0]] || allowedStyles['*'];
+    }
+
+    /**
+     * Filters the existing attributes for the given property. Discards any attributes
+     * which don't match the whitelist.
+     *
+     * @param  {object} attributeObject - Object representing the current css property.
+     * @property {string} type          - Typically 'declaration'.
+     * @property {string} property      - The CSS property, i.e 'color'.
+     * @property {string} value         - The corresponding value to the css property, i.e 'red'.
+     * @return {abstractSyntaxTree}     - Object representation of attributes and values.
+     */
+    if (selectedRule) {
+      var filteredDeclarations = astRules.declarations.reduce(function(allowedDeclarationsList,attributeObject) {
+        // If this property is whitelisted...
+        if (selectedRule.hasOwnProperty(attributeObject.property)) {
+          var matchesRegex = selectedRule[attributeObject.property].some(function(regularExpression) {
+            return regularExpression.test(attributeObject.value);
+          });
+
+          if (matchesRegex) {
+            allowedDeclarationsList.push(attributeObject);
+          }
+          return allowedDeclarationsList;
+        }
+      },
+      []);
+
+      filteredAST.stylesheet.rules[0].declarations = filteredDeclarations;
+    }
+
+    return filteredAST;
   }
-
-  filteredAST.stylesheet.rules[0].declarations = filteredDeclarations;
-
-  return filteredAST;
-}
 
   function filterClasses(classes, allowed) {
     if (!allowed) {
@@ -505,73 +519,3 @@ sanitizeHtml.simpleTransform = function(newTagName, newAttribs, merge) {
     };
   };
 };
-
-// console.log('im about to run')
-var myOptions = {
-  allowedTags: [ 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'ul', 'ol', 'li', 'strong', 'em', 'u', 'br', 'span' ],
-  allowedAttributes: {
-  'a': [ 'href', 'name', 'target', 'style' ],
-  '*': [ 'style' ]
-},
-  allowedStyles: {
-    '*': {
-      'color': [ /red/, /green/],
-      'font-family': [ 'helvetica' ]
-    }
-  },
-  // URL schemes we permit
-  allowedSchemes: [ 'http', 'https', 'mailto' ],
-  allowProtocolRelative: true
-}
-
-sanitizeHtml('<h1><a target="blank" href="https://www.google.com">BLAH BLAH</a></h1><p data-test="no" style="color: red; font-family: helvetica;"><span style="color: green;">Get a free</span> 6" Sub!</p>', myOptions)
-
-
-/**
- * [filterCss description]
- *
- * @param  {object} abstractSyntaxTree - Object representation of CSS attributes
- * @property {object} abstractSyntaxTree.type
- * @property {object} abstractSyntaxTree.stylesheet
- * @property {array[object]} abstractSyntaxTree.stylesheet
- * @property {array[object]} abstractSyntaxTree.parsingErrors
- * @return {object}                    [description]
- */
-// function filterCss(abstractSyntaxTree, allowedStyles) {
-//   if (!allowedStyles) {
-//     return abstractSyntaxTree
-//   }
-//   console.log(abstractSyntaxTree)
-//   var originalAst = Object.assign({}, abstractSyntaxTree);
-//   // there should only be one element in the abstractSyntaxTree array based on how we set it up
-//   abstractSyntaxTree = abstractSyntaxTree.stylesheet.rules[0];
-//   // Check if selector is in our allowed styles
-//   if(options.allowedStyles) {
-//     if(options.allowedStyles[abstractSyntaxTree.selectors[0]] || options.allowedStyles['*']) {
-//       var allowedDeclarations = [];
-//       abstractSyntaxTree.declarations.forEach(function(value) {
-//         // Is specific style allowed?
-//         // First check if allowed in glob
-//         if(options.allowedStyles['*']) {
-//           if(options.allowedStyles['*'][value.property]) {
-//             if(options.allowedStyles['*'][value.property] === '*' || options.allowedStyles['*'][value.property].indexOf(value.value) > -1) {
-//               allowedDeclarations.push(value);
-//             }
-//           }
-//         } else if (options.allowedStyles[abstractSyntaxTree.selectors[0]]) {
-//           if(options.allowedStyles[abstractSyntaxTree.selectors[0]][value.property]) {
-//             if(options.allowedStyles[abstractSyntaxTree.selectors[0]][value.property] === '*' || options.allowedStyles[abstractSyntaxTree.selectors[0]][value.property].indexOf(value.value) > -1) {
-//               allowedDeclarations.push(value);
-//             }
-//           }
-//         }
-//       });
-//       originalAst.stylesheet.rules[0].declarations = allowedDeclarations;
-//       return originalAst;
-//     } else {
-//       return false;
-//     }
-//   } else {
-//     return originalAst;
-//   }
-// }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,10 +31,13 @@
         "repeat-string": "1.6.1"
       }
     },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    "ansi-styles": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "requires": {
+        "color-convert": "1.9.1"
+      }
     },
     "array-filter": {
       "version": "0.0.1",
@@ -87,11 +90,6 @@
       "requires": {
         "acorn": "4.0.13"
       }
-    },
-    "atob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
-      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -361,6 +359,16 @@
         "lazy-cache": "1.0.4"
       }
     },
+    "chalk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "requires": {
+        "ansi-styles": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "4.5.0"
+      }
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -381,6 +389,19 @@
         "right-align": "0.1.3",
         "wordwrap": "0.0.2"
       }
+    },
+    "color-convert": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combine-source-map": {
       "version": "0.7.2",
@@ -505,32 +526,6 @@
         "pbkdf2": "3.0.13",
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.5"
-      }
-    },
-    "css": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
-      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
-      "requires": {
-        "inherits": "2.0.3",
-        "source-map": "0.1.43",
-        "source-map-resolve": "0.3.1",
-        "urix": "0.1.0"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
       }
     },
     "date-now": {
@@ -699,6 +694,11 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -749,6 +749,11 @@
       "requires": {
         "function-bind": "1.1.1"
       }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
     },
     "hash-base": {
       "version": "2.0.2",
@@ -1351,6 +1356,23 @@
         "sha.js": "2.4.8"
       }
     },
+    "postcss": {
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+      "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+      "requires": {
+        "chalk": "2.3.0",
+        "source-map": "0.6.1",
+        "supports-color": "4.5.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -1458,11 +1480,6 @@
         "path-parse": "1.0.5"
       }
     },
-    "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -1523,22 +1540,6 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
-    },
-    "source-map-resolve": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-      "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
-      "requires": {
-        "atob": "1.1.3",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.3.0",
-        "urix": "0.1.0"
-      }
-    },
-    "source-map-url": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
-      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk="
     },
     "srcset": {
       "version": "1.0.0",
@@ -1741,6 +1742,14 @@
         "minimist": "1.2.0"
       }
     },
+    "supports-color": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+      "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+      "requires": {
+        "has-flag": "2.0.0"
+      }
+    },
     "syntax-error": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
@@ -1848,11 +1857,6 @@
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
       "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
       "dev": true
-    },
-    "urix": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
       "version": "0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanitize-html",
-  "version": "1.14.3",
+  "version": "1.15.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -30,6 +30,11 @@
         "longest": "1.0.1",
         "repeat-string": "1.6.1"
       }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "array-filter": {
       "version": "0.0.1",
@@ -82,6 +87,11 @@
       "requires": {
         "acorn": "4.0.13"
       }
+    },
+    "atob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -495,6 +505,32 @@
         "pbkdf2": "3.0.13",
         "public-encrypt": "4.0.0",
         "randombytes": "2.0.5"
+      }
+    },
+    "css": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
+      "requires": {
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.3.1",
+        "urix": "0.1.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
       }
     },
     "date-now": {
@@ -933,6 +969,11 @@
       "requires": {
         "astw": "2.2.0"
       }
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.escaperegexp": {
       "version": "4.1.2",
@@ -1407,6 +1448,11 @@
         "path-parse": "1.0.5"
       }
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -1467,6 +1513,22 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
+    },
+    "source-map-resolve": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+      "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+      "requires": {
+        "atob": "1.1.3",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.3.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk="
     },
     "srcset": {
       "version": "1.0.0",
@@ -1776,6 +1838,11 @@
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
       "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
       "dev": true
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
     },
     "url": {
       "version": "0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -980,11 +980,21 @@
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
     },
+    "lodash.isarray": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
+      "integrity": "sha1-KspJayjEym1yZxUxNZDALm6jRAM="
+    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
+    },
+    "lodash.mergewith": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+      "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
     },
     "longest": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "htmlparser2": "^3.9.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.escaperegexp": "^4.1.2",
+    "lodash.isarray": "^4.0.0",
+    "lodash.mergewith": "^4.6.0",
     "srcset": "^1.0.0",
     "xtend": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
   "author": "P'unk Avenue LLC",
   "license": "MIT",
   "dependencies": {
-    "css": "^2.2.1",
     "htmlparser2": "^3.9.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.isarray": "^4.0.0",
     "lodash.mergewith": "^4.6.0",
+    "postcss": "^6.0.14",
     "srcset": "^1.0.0",
     "xtend": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "author": "P'unk Avenue LLC",
   "license": "MIT",
   "dependencies": {
+    "css": "^2.2.1",
     "htmlparser2": "^3.9.0",
     "regexp-quote": "0.0.0",
     "xtend": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "css": "^2.2.1",
     "htmlparser2": "^3.9.0",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.escaperegexp": "^4.1.2",
     "srcset": "^1.0.0",
     "xtend": "^4.0.0"

--- a/test/test.js
+++ b/test/test.js
@@ -396,7 +396,7 @@ describe('sanitizeHtml', function() {
           }
         }
       ),
-      '<p style="text-align: center;">Text</p>'
+      '<p style="text-align:center;">Text</p>'
     );
   });
   it('should not be faked out by double <', function() {
@@ -472,5 +472,27 @@ describe('sanitizeHtml', function() {
       }),
       "<Archer><Sterling>I am</Sterling></Archer>"
     );
+  });
+  it('should sanitize styles correctly', function() {
+    var sanitizeString = '<p dir="ltr"><strong>beste</strong><em>testestes</em><s>testestset</s><u>testestest</u></p><ul dir="ltr"> <li><u>test</u></li></ul><blockquote dir="ltr"> <ol> <li><u>​test</u></li><li><u>test</u></li><li style="text-align: right;"><u>test</u></li><li style="text-align: justify;"><u>test</u></li></ol> <p><u><span style="color:#00FF00;">test</span></u></p><p><span style="color:#00FF00"><span style="font-size:36px;">TESTETESTESTES</span></span></p></blockquote>';
+    var expected = '<p dir="ltr"><strong>beste</strong><em>testestes</em><s>testestset</s><u>testestest</u></p><ul dir="ltr"> <li><u>test</u></li></ul><blockquote dir="ltr"> <ol> <li><u>​test</u></li><li><u>test</u></li><li style="text-align: right;"><u>test</u></li><li style="text-align: justify;"><u>test</u></li></ol> <p><u><span style="color:#00FF00;">test</span></u></p><p><span style="color:#00FF00;"><span style="font-size:36px;">TESTETESTESTES</span></span></p></blockquote>';
+    assert.equal(
+      sanitizeHtml(sanitizeString, {
+        allowedTags: false,
+        allowedAttributes: {
+          '*': ["dir"],
+          p: ["dir", "style"],
+          li: ["style"],
+          span: ["style"]
+        },
+        allowedStyles: {
+          '*': {
+            'color': '*',
+            'text-align': ['left','right','center','justify','initial','inherit'],
+            'font-size': '*'
+          }
+        }
+      }).replace(/ /g,''), expected.replace(/ /g,'')
+    )
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -503,5 +503,39 @@ describe('sanitizeHtml', function() {
       }),
       "<span></span>"
     );
+  });
+  it('Should remote invalid styles', function() {
+    assert.equal(
+      sanitizeHtml("<span style='color: blue; text-align: justify'></span>", {
+        allowedTags: false,
+        allowedAttributes: {
+          "span": ["style"]
+        },
+        allowedStyles: {
+          'span': {
+            "color": "blue",
+            "text-align": ['left']
+          }
+        }
+      }), '<span style="color:blue;"></span>'
+    );
+  });
+  it('Should allow a specific style from global', function() {
+    assert.equal(
+      sanitizeHtml("<span style='color: yellow;'></span>", {
+        allowedTags: false,
+        allowedAttributes: {
+          "span": ["style"]
+        },
+        allowedStyles: {
+          '*': {
+            "color": ["yellow"]
+          },
+          'span': {
+            "color": ["green"]
+          }
+        }
+      }), '<span style="color:yellow;"></span>'
+    );
   })
 });

--- a/test/test.js
+++ b/test/test.js
@@ -495,4 +495,13 @@ describe('sanitizeHtml', function() {
       }).replace(/ /g,''), expected.replace(/ /g,'')
     )
   });
+  it('Should remove empty style tags', function() {
+    assert.equal(
+      sanitizeHtml("<span style=''></span>", {
+        allowedTags: false,
+        allowedAttributes: false
+      }),
+      "<span></span>"
+    );
+  })
 });

--- a/test/test.js
+++ b/test/test.js
@@ -556,7 +556,7 @@ describe('sanitizeHtml', function() {
     assert.equal(
       sanitizeHtml('<img src="fallback.jpg" srcset="foo.jpg 100w 2x, bar.jpg 200w 1x" />', {
         allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
-        allowedAttributes: { img: [ 'src', 'srcset' ] }        
+        allowedAttributes: { img: [ 'src', 'srcset' ] }
       }),
       '<img src="fallback.jpg" srcset="foo.jpg 100w 2x, bar.jpg 200w 1x" />'
     );
@@ -565,7 +565,7 @@ describe('sanitizeHtml', function() {
     assert.equal(
       sanitizeHtml('<img src="fallback.jpg" srcset="foo.jpg 100w 2x, bar.jpg 200w 1x, javascript:alert(1) 100w 2x" />', {
         allowedTags: sanitizeHtml.defaults.allowedTags.concat([ 'img' ]),
-        allowedAttributes: { img: [ 'src', 'srcset' ] }        
+        allowedAttributes: { img: [ 'src', 'srcset' ] }
       }),
       '<img src="fallback.jpg" srcset="foo.jpg 100w 2x, bar.jpg 200w 1x" />'
     );
@@ -593,9 +593,10 @@ describe('sanitizeHtml', function() {
         },
         allowedStyles: {
           '*': {
-            'color': '*',
-            'text-align': ['left','right','center','justify','initial','inherit'],
-            'font-size': '*'
+            // Matches hex
+            'color': [/\#(0x)?[0-9a-f]+/i],
+            'text-align': [/left/, /right/, /center/, /justify/, /initial/, /inherit/],
+            'font-size': [/36px/]
           }
         }
       }).replace(/ /g,''), expected.replace(/ /g,'')
@@ -619,8 +620,8 @@ describe('sanitizeHtml', function() {
         },
         allowedStyles: {
           'span': {
-            "color": "blue",
-            "text-align": ['left']
+            "color": [/blue/],
+            "text-align": [/left/]
           }
         }
       }), '<span style="color:blue;"></span>'
@@ -628,20 +629,22 @@ describe('sanitizeHtml', function() {
   });
   it('Should allow a specific style from global', function() {
     assert.equal(
-      sanitizeHtml("<span style='color: yellow;'></span>", {
+      sanitizeHtml("<span style='color: yellow; text-align: center; font-family: helvetica;'></span>", {
         allowedTags: false,
         allowedAttributes: {
           "span": ["style"]
         },
         allowedStyles: {
           '*': {
-            "color": ["yellow"]
+            "color": [/yellow/],
+            "text-align": [/center/]
           },
           'span': {
-            "color": ["green"]
+            "color": [/green/],
+            "font-family": [/helvetica/]
           }
         }
-      }), '<span style="color:yellow;"></span>'
+      }), '<span style="color:yellow;text-align:center;font-family:helvetica;"></span>'
     );
   });
 });


### PR DESCRIPTION
This is an updated pull request from @cwill747 [original](https://github.com/punkave/sanitize-html/pull/98)

The `allowedStyles` option now requires a list of regular expressions for whitelisting. This makes whitelisting attributes such as font-size: 30px much easier because all unit types don't have to be accounted for within our logic.