### PR TITLE
Remove ES6 syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = sanitizeHtml;
 //   * unexpected-character-in-attribute-name
 // We exclude the empty string because it's impossible to get to the after
 // attribute name state with an empty attribute name buffer.
-const VALID_HTML_ATTRIBUTE_NAME = /^[^\0\t\n\f\r /<=>]+$/;
+var VALID_HTML_ATTRIBUTE_NAME = /^[^\0\t\n\f\r /<=>]+$/;
 
 // Ignore the _recursing flag; it's there for recursive
 // invocation as a guard against this exploit:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanitize-html",
-  "version": "1.15.0",
+  "version": "1.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
ES6 syntax was introduced in PR #174, with the introduction of a single `const`. Until then, this package was fully ES5 compatible requiring no transpiling step for use in older (<IE11) browsers.

Since this use of `const` seems to be the exception, I'm hoping we can revert back simply using `var`.

In the future, if we want to introduce ES6 syntax then maybe we can take one of two approaches:

1. a major version change (if we want to drop support for older browsers)
2. include a transpile step in the browser build (if we want to continue supporting older browsers)
