### PR TITLE
replace lodash.isarray with Array.isArray

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ var htmlparser = require('htmlparser2');
 var extend = require('xtend');
 var quoteRegexp = require('lodash.escaperegexp');
 var cloneDeep = require('lodash.clonedeep');
-var isArray = require('lodash.isarray');
 var mergeWith = require('lodash.mergewith');
 var srcset = require('srcset');
 var postcss = require('postcss');
@@ -416,7 +415,7 @@ function sanitizeHtml(html, options, _recursing) {
         cloneDeep(allowedStyles[astRules.selector]),
         allowedStyles['*'],
         function(objValue, srcValue) {
-          if (isArray(objValue)) {
+          if (Array.isArray(objValue)) {
             return objValue.concat(srcValue);
           }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sanitize-html",
-  "version": "1.15.0",
+  "version": "1.16.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -984,11 +984,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
-    },
-    "lodash.isarray": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-4.0.0.tgz",
-      "integrity": "sha1-KspJayjEym1yZxUxNZDALm6jRAM="
     },
     "lodash.memoize": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "htmlparser2": "^3.9.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.escaperegexp": "^4.1.2",
-    "lodash.isarray": "^4.0.0",
     "lodash.mergewith": "^4.6.0",
     "postcss": "^6.0.14",
     "srcset": "^1.0.0",


### PR DESCRIPTION
Fixes the deprecation issue.

```
sanitize-html > lodash.isarray@4.0.0: This package is deprecated. Use Array.isArray.
```