### PR TITLE
Allow filtering of iframe src urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The syntax of poorly closed `p` and `img` elements is cleaned up.
 
 `href` attributes are validated to ensure they only contain `http`, `https`, `ftp` and `mailto` URLs. Relative URLs are also allowed. Ditto for `src` attributes.
 
-Filtering particular domains as a `src` to an iframe tag is also supported. 
+Allowing particular urls as a `src` to an iframe tag by filtering hostnames is also supported. 
 
 HTML comments are not preserved.
 
@@ -85,7 +85,7 @@ clean = sanitizeHtml(dirty, {
   allowedAttributes: {
     'a': [ 'href' ]
   },
-  allowedIframeDomains: ['youtube.com']
+  allowedIframeHostnames: ['www.youtube.com']
 });
 ```
 
@@ -119,7 +119,7 @@ selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', '
 allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
 allowedSchemesByTag: {},
 allowProtocolRelative: true,
-allowedIframeDomains: ['youtube.com', 'vimeo.com']
+allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
 ```
 
 #### "What if I want to allow all tags or all attributes?"
@@ -300,14 +300,14 @@ Note that the text passed to the `textFilter` method is already escaped for safe
 
 ### Iframe Filters
 
-If you would like to allow iframe tags but want to control the domains that are allowed through you can provide an array of domains that you would like to allow as iframe sources. This domain is a property in the options object passed as an argument to the `sanitze-html` function. 
+If you would like to allow iframe tags but want to control the domains that are allowed through you can provide an array of hostnames that you would like to allow as iframe sources. This hostname is a property in the options object passed as an argument to the `sanitze-html` function. 
 
-This array will be checked against the html that is passed to the function and return only `src` urls that include the allowed domains in the object. The url in the html that is passed must be formatted correctly (valid hostname) as an embedded iframe otherwise the module will strip out the src from the iframe. 
+This array will be checked against the html that is passed to the function and return only `src` urls that include the allowed hostnames in the object. The url in the html that is passed must be formatted correctly (valid hostname) as an embedded iframe otherwise the module will strip out the src from the iframe. 
 
 Make sure to pass a valid hostname along with the domain you wish to allow, i.e.: 
 
 ```javascript
-  allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
+  allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
 ```
 
 **Remember that the `iframe` tag must be allowed as well as the `src` attribute.**
@@ -321,7 +321,7 @@ clean = sanitizeHtml('<p><iframe src="https://www.youtube.com/embed/nykIhs12345"
     'p': [ 'fancy', 'simple' ],
     'iframe': ['src']
   },
-  allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
+  allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
 });
 ```
 
@@ -334,7 +334,7 @@ clean = sanitizeHtml('<p><iframe src="https://www.youtube.net/embed/nykIhs12345"
     'p': [ 'fancy', 'simple' ],
     'iframe': ['src']
   },
-  allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
+  allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
 });
 ```
 
@@ -347,7 +347,7 @@ clean = sanitizeHtml('<p><iframe src="https://www.vimeo/video/12345"></iframe><p
     'p': [ 'fancy', 'simple' ],
     'iframe': ['src']
   },
-  allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
+  allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,13 @@ Note that the text passed to the `textFilter` method is already escaped for safe
 
 If you would like to allow iframe tags but want to control the domains that are allowed through you can provide an array of domains that you would like to allow as iframe sources. This domain is a property in the options object passed as an argument to the `sanitze-html` function. 
 
-This array will be checked against the html that is passed to the function and return only `src` urls that include the allowed domains in the object. 
+This array will be checked against the html that is passed to the function and return only `src` urls that include the allowed domains in the object. The url in the html that is passed must be formatted correctly (valid hostname) as an embedded iframe otherwise the module will strip out the src from the iframe. 
+
+You can get specific with the domain by specifying the allowed hostname i.e.: 
+
+```javascript
+  allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
+```
 
 **Remember that the `iframe` tag must be allowed as well as the `src` attribute.**
 
@@ -330,9 +336,11 @@ clean = sanitizeHtml(<p><iframe src="https://www.youtube.net/embed/nykIhs12345">
   },
   allowedIframeDomains: ['youtube.com', 'twitch.tv']
 });
+```
 
 or 
 
+```javascript
 clean = sanitizeHtml(<p><iframe src="https://www.vimeo/video/12345"></iframe><p>, {
   allowedTags: [ 'p', 'em', 'strong', 'iframe' ],
   allowedClasses: {

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Make sure to pass a valid hostname along with the domain you wish to allow, i.e.
 For example:
 
 ```javascript
-clean = sanitizeHtml(<p><iframe src="https://www.youtube.com/embed/nykIhs12345"></iframe><p>, {
+clean = sanitizeHtml('<p><iframe src="https://www.youtube.com/embed/nykIhs12345"></iframe><p>', {
   allowedTags: [ 'p', 'em', 'strong', 'iframe' ],
   allowedClasses: {
     'p': [ 'fancy', 'simple' ],
@@ -328,7 +328,7 @@ clean = sanitizeHtml(<p><iframe src="https://www.youtube.com/embed/nykIhs12345">
 will pass through as safe whereas:
 
 ```javascript
-clean = sanitizeHtml(<p><iframe src="https://www.youtube.net/embed/nykIhs12345"></iframe><p>, {
+clean = sanitizeHtml('<p><iframe src="https://www.youtube.net/embed/nykIhs12345"></iframe><p>', {
   allowedTags: [ 'p', 'em', 'strong', 'iframe' ],
   allowedClasses: {
     'p': [ 'fancy', 'simple' ],
@@ -341,7 +341,7 @@ clean = sanitizeHtml(<p><iframe src="https://www.youtube.net/embed/nykIhs12345">
 or 
 
 ```javascript
-clean = sanitizeHtml(<p><iframe src="https://www.vimeo/video/12345"></iframe><p>, {
+clean = sanitizeHtml('<p><iframe src="https://www.vimeo/video/12345"></iframe><p>', {
   allowedTags: [ 'p', 'em', 'strong', 'iframe' ],
   allowedClasses: {
     'p': [ 'fancy', 'simple' ],

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The syntax of poorly closed `p` and `img` elements is cleaned up.
 
 `href` attributes are validated to ensure they only contain `http`, `https`, `ftp` and `mailto` URLs. Relative URLs are also allowed. Ditto for `src` attributes.
 
+Filtering particular domains as a `src` to an iframe tag is also supported. 
+
 HTML comments are not preserved.
 
 ## Requirements
@@ -82,7 +84,8 @@ clean = sanitizeHtml(dirty, {
   allowedTags: [ 'b', 'i', 'em', 'strong', 'a' ],
   allowedAttributes: {
     'a': [ 'href' ]
-  }
+  },
+  allowedIframeDomains: ['youtube.com']
 });
 ```
 
@@ -115,7 +118,8 @@ selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', '
 // URL schemes we permit
 allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
 allowedSchemesByTag: {},
-allowProtocolRelative: true
+allowProtocolRelative: true,
+allowedIframeDomains: ['youtube.com', 'vimeo.com']
 ```
 
 #### "What if I want to allow all tags or all attributes?"
@@ -293,6 +297,54 @@ sanitizeHtml(
 ```
 
 Note that the text passed to the `textFilter` method is already escaped for safe display as HTML. You may add markup and use entity escape sequences in your `textFilter`.
+
+### Iframe Filters
+
+If you would like to allow iframe tags but want to control the domains that are allowed through you can provide an array of domains that you would like to allow as iframe sources. This domain is a property in the options object passed as an argument to the `sanitze-html` function. 
+
+This array will be checked against the html that is passed to the function and return only `src` urls that include the allowed domains in the object. 
+
+**Remember that the `iframe` tag must be allowed as well as the `src` attribute.**
+
+For example:
+
+```javascript
+clean = sanitizeHtml(<p><iframe src="https://www.youtube.com/embed/nykIhs12345"></iframe><p>, {
+  allowedTags: [ 'p', 'em', 'strong', 'iframe' ],
+  allowedClasses: {
+    'p': [ 'fancy', 'simple' ],
+    'iframe': ['src']
+  },
+  allowedIframeDomains: ['youtube.com', 'twitch.tv']
+});
+```
+
+will pass through as safe whereas:
+
+```javascript
+clean = sanitizeHtml(<p><iframe src="https://www.youtube.net/embed/nykIhs12345"></iframe><p>, {
+  allowedTags: [ 'p', 'em', 'strong', 'iframe' ],
+  allowedClasses: {
+    'p': [ 'fancy', 'simple' ],
+    'iframe': ['src']
+  },
+  allowedIframeDomains: ['youtube.com', 'twitch.tv']
+});
+
+or 
+
+clean = sanitizeHtml(<p><iframe src="https://www.vimeo/video/12345"></iframe><p>, {
+  allowedTags: [ 'p', 'em', 'strong', 'iframe' ],
+  allowedClasses: {
+    'p': [ 'fancy', 'simple' ],
+    'iframe': ['src']
+
+  },
+  allowedIframeDomains: ['youtube.com', 'twitch.tv']
+});
+```
+
+will return an empty iframe tag.
 
 ### Allowed CSS Classes
 

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ If you would like to allow iframe tags but want to control the domains that are 
 
 This array will be checked against the html that is passed to the function and return only `src` urls that include the allowed domains in the object. The url in the html that is passed must be formatted correctly (valid hostname) as an embedded iframe otherwise the module will strip out the src from the iframe. 
 
-You can get specific with the domain by specifying the allowed hostname i.e.: 
+Make sure to pass a valid hostname along with the domain you wish to allow, i.e.: 
 
 ```javascript
   allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
@@ -321,7 +321,7 @@ clean = sanitizeHtml(<p><iframe src="https://www.youtube.com/embed/nykIhs12345">
     'p': [ 'fancy', 'simple' ],
     'iframe': ['src']
   },
-  allowedIframeDomains: ['youtube.com', 'twitch.tv']
+  allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
 });
 ```
 
@@ -334,7 +334,7 @@ clean = sanitizeHtml(<p><iframe src="https://www.youtube.net/embed/nykIhs12345">
     'p': [ 'fancy', 'simple' ],
     'iframe': ['src']
   },
-  allowedIframeDomains: ['youtube.com', 'twitch.tv']
+  allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
 });
 ```
 
@@ -346,9 +346,8 @@ clean = sanitizeHtml(<p><iframe src="https://www.vimeo/video/12345"></iframe><p>
   allowedClasses: {
     'p': [ 'fancy', 'simple' ],
     'iframe': ['src']
-
   },
-  allowedIframeDomains: ['youtube.com', 'twitch.tv']
+  allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lodash.mergewith": "^4.6.0",
     "postcss": "^6.0.14",
     "srcset": "^1.0.0",
+    "url": "^0.11.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "lodash.mergewith": "^4.6.0",
     "postcss": "^6.0.14",
     "srcset": "^1.0.0",
-    "url": "^0.11.0",
     "xtend": "^4.0.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -213,8 +213,7 @@ function sanitizeHtml(html, options, _recursing) {
                   value.indexOf('https:') < 0 &&
                   value.substring(0, 2) === '//') {
                 var prefix = 'https:';
-                var tempValue = value;
-                value = prefix.concat(tempValue);            
+                value = prefix.concat(value);            
               }
               try {
                 parsed = url.parse(value);

--- a/src/index.js
+++ b/src/index.js
@@ -215,12 +215,14 @@ function sanitizeHtml(html, options, _recursing) {
               }
               try {
                 parsed = url.parse(value);
-                var whitelistedHostnames = options.allowedIframeHostnames.find(function(hostname) {
-                  return hostname === parsed.hostname;
-                });
-                if (!whitelistedHostnames) {
-                  delete frame.attribs[a];
-                  return;
+                if (options.allowedIframeHostnames) {
+                  var whitelistedHostnames = options.allowedIframeHostnames.find(function(hostname) {
+                    return hostname === parsed.hostname;
+                  });
+                  if (!whitelistedHostnames) {
+                    delete frame.attribs[a];
+                    return;
+                  }
                 }
               } catch (e) {
                 // Unparseable iframe src
@@ -531,9 +533,7 @@ sanitizeHtml.defaults = {
   // URL schemes we permit
   allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
   allowedSchemesByTag: {},
-  allowProtocolRelative: true,
-  // Hostnames we permit to be included in src attribute of an iframe tag
-  allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
+  allowProtocolRelative: true
 };
 
 sanitizeHtml.simpleTransform = function(newTagName, newAttribs, merge) {

--- a/src/index.js
+++ b/src/index.js
@@ -209,18 +209,16 @@ function sanitizeHtml(html, options, _recursing) {
             }
             if (name === 'iframe' && a === 'src') {
               //Check if value contains proper hostname prefix
-              if (value.indexOf('http:') < 0 && 
-                  value.indexOf('https:') < 0 &&
-                  value.substring(0, 2) === '//') {
+              if (value.substring(0, 2) === '//') {
                 var prefix = 'https:';
                 value = prefix.concat(value);            
               }
               try {
                 parsed = url.parse(value);
-                var whitelistedDomains = options.allowedIframeDomains.find(function(domain) {
-                  return domain === parsed.hostname;
+                var whitelistedHostnames = options.allowedIframeHostnames.find(function(hostname) {
+                  return hostname === parsed.hostname;
                 });
-                if (!whitelistedDomains) {
+                if (!whitelistedHostnames) {
                   delete frame.attribs[a];
                   return;
                 }
@@ -534,8 +532,8 @@ sanitizeHtml.defaults = {
   allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
   allowedSchemesByTag: {},
   allowProtocolRelative: true,
-  // Domains we permit to be included in src attribute of an iframe tag
-  allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
+  // Hostnames we permit to be included in src attribute of an iframe tag
+  allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
 };
 
 sanitizeHtml.simpleTransform = function(newTagName, newAttribs, merge) {

--- a/src/index.js
+++ b/src/index.js
@@ -206,7 +206,15 @@ function sanitizeHtml(html, options, _recursing) {
                 return;
               }
             }
-
+            if (name === 'iframe' && a === 'src') {
+              var whitelistedUrls = options.allowedUrls.filter(function(url) {
+                return value.includes(url);
+              })
+              if (!whitelistedUrls.length) {
+                delete frame.attribs[a];
+                return;
+              }
+            } 
             if (a === 'srcset') {
               try {
                 var parsed = srcset.parse(value);
@@ -233,7 +241,6 @@ function sanitizeHtml(html, options, _recursing) {
                 return;
               }
             }
-
             if (a === 'class') {
               value = filterClasses(value, allowedClassesMap[name]);
               if (!value.length) {
@@ -511,7 +518,9 @@ sanitizeHtml.defaults = {
   // URL schemes we permit
   allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
   allowedSchemesByTag: {},
-  allowProtocolRelative: true
+  allowProtocolRelative: true,
+  // Allowed urls we permit to be included in src attribute of an iframe tag
+  allowedUrls: ['youtube.com', 'vimeo.com']
 };
 
 sanitizeHtml.simpleTransform = function(newTagName, newAttribs, merge) {

--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,7 @@ function sanitizeHtml(html, options, _recursing) {
               }
             }
             if (name === 'iframe' && a === 'src') {
-              var whitelistedUrls = options.allowedUrls.filter(function(url) {
+              var whitelistedUrls = options.allowedIframeDomains.filter(function(url) {
                 return value.includes(url);
               })
               if (!whitelistedUrls.length) {
@@ -505,13 +505,16 @@ var htmlParserDefaults = {
 sanitizeHtml.defaults = {
   allowedTags: [ 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol',
     'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'hr', 'br', 'div',
-    'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre' ],
+    'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre', 'iframe' ],
   allowedAttributes: {
     a: [ 'href', 'name', 'target' ],
     // We don't currently allow img itself by default, but this
     // would make sense if we did. You could add srcset here,
     // and if you do the URL is checked for safety
-    img: [ 'src' ]
+    img: [ 'src' ],
+    iframe: {
+      attributes: 'src',
+    }
   },
   // Lots of these won't come up by default because we don't allow them
   selfClosing: [ 'img', 'br', 'hr', 'area', 'base', 'basefont', 'input', 'link', 'meta' ],
@@ -519,8 +522,8 @@ sanitizeHtml.defaults = {
   allowedSchemes: [ 'http', 'https', 'ftp', 'mailto' ],
   allowedSchemesByTag: {},
   allowProtocolRelative: true,
-  // Allowed urls we permit to be included in src attribute of an iframe tag
-  allowedUrls: ['youtube.com', 'vimeo.com']
+  // Domains we permit to be included in src attribute of an iframe tag
+  allowedIframeDomains: ['youtube.com', 'vimeo.com']
 };
 
 sanitizeHtml.simpleTransform = function(newTagName, newAttribs, merge) {

--- a/test/test.js
+++ b/test/test.js
@@ -652,7 +652,7 @@ describe('sanitizeHtml', function() {
       sanitizeHtml("<iframe src='https://www.youtube.com/embed/c2IlcS7AHxM'></iframe>", {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
-        allowedIframeDomains: ['youtube.com', 'vimeo.com']
+        allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
       }), '<iframe src="https://www.youtube.com/embed/c2IlcS7AHxM"></iframe>'
     );
   });
@@ -661,16 +661,16 @@ describe('sanitizeHtml', function() {
       sanitizeHtml("<iframe src='https://www.embed.vevo.com/USUV71704255'></iframe>", {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
-        allowedIframeDomains: ['youtube.com', 'vimeo.com']
+        allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
       }), '<iframe></iframe>'
     );
   });
-  it('Should not allow urls that do not have proper hostname', function() {
+  it('Should not allow iframe urls that do not have proper hostname', function() {
     assert.equal(
-      sanitizeHtml("<iframe src='//www.youtube.com/embed/c2IlcS7AHxM'></iframe>", {
+      sanitizeHtml("<iframe src='//www.vimeo.com/embed/c2IlcS7AHxM'></iframe>", {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
-        allowedIframeDomains: ['youtube.com', 'vimeo.com']
+        allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
       }), '<iframe></iframe>'
     );
   });

--- a/test/test.js
+++ b/test/test.js
@@ -649,7 +649,7 @@ describe('sanitizeHtml', function() {
   });
   it('Should allow only hostnames in an iframe that are whitelisted', function() {
     assert.equal(
-      sanitizeHtml("<iframe src='https://www.youtube.com/embed/c2IlcS7AHxM'></iframe>", {
+      sanitizeHtml('<iframe src="https://www.youtube.com/embed/c2IlcS7AHxM"></iframe>', {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
         allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
@@ -658,7 +658,7 @@ describe('sanitizeHtml', function() {
   });
   it('Should remove iframe src urls that are not inlcuded in whitelisted hostnames', function() {
     assert.equal(
-      sanitizeHtml("<iframe src='https://www.embed.vevo.com/USUV71704255'></iframe>", {
+      sanitizeHtml('<iframe src="https://www.embed.vevo.com/USUV71704255"></iframe>', {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
         allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
@@ -667,11 +667,19 @@ describe('sanitizeHtml', function() {
   });
   it('Should not allow iframe urls that do not have proper hostname', function() {
     assert.equal(
-      sanitizeHtml("<iframe src='//www.vimeo.com/embed/c2IlcS7AHxM'></iframe>", {
+      sanitizeHtml('<iframe src="//www.vimeo.com/embed/c2IlcS7AHxM"></iframe>', {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
         allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
       }), '<iframe></iframe>'
+    );
+  });
+  it('Should allow iframe through if no hostname option is set', function() {
+    assert.equal(
+      sanitizeHtml('<iframe src="https://www.vimeo.com/embed/c2IlcS7AHxM"></iframe>', {
+        allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
+        allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']}
+      }), '<iframe src="https://www.vimeo.com/embed/c2IlcS7AHxM"></iframe>'
     );
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -656,9 +656,18 @@ describe('sanitizeHtml', function() {
       }), '<iframe src="https://www.youtube.com/embed/c2IlcS7AHxM"></iframe>'
     );
   });
-  it('Should remove iframe src domains that are not whitelisted', function() {
+  it('Should remove iframe src urls that are not inlcuded in whitelisted domains', function() {
     assert.equal(
       sanitizeHtml("<iframe src='https://www.embed.vevo.com/USUV71704255'></iframe>", {
+        allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
+        allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
+        allowedIframeDomains: ['youtube.com', 'vimeo.com']
+      }), '<iframe></iframe>'
+    );
+  });
+  it('Should not allow urls that do not have proper hostname', function() {
+    assert.equal(
+      sanitizeHtml("<iframe src='//www.youtube.com/embed/c2IlcS7AHxM'></iframe>", {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
         allowedIframeDomains: ['youtube.com', 'vimeo.com']

--- a/test/test.js
+++ b/test/test.js
@@ -647,4 +647,22 @@ describe('sanitizeHtml', function() {
       }), '<span style="color:yellow;text-align:center;font-family:helvetica;"></span>'
     );
   });
+  it('Should allow only urls in an iframe that are whitelisted', function() {
+    assert.equal(
+      sanitizeHtml("<iframe src='https://www.youtube.com/embed/c2IlcS7AHxM'></iframe>", {
+        allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
+        allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
+        allowedUrls: ['youtube.com', 'vimeo.com']
+      }), '<iframe src="https://www.youtube.com/embed/c2IlcS7AHxM"></iframe>'
+    );
+  });
+  it('Should remove iframe src urls that are not whitelisted', function() {
+    assert.equal(
+      sanitizeHtml("<iframe src='https://www.embed.vevo.com/USUV71704255'></iframe>", {
+        allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
+        allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
+        allowedUrls: ['youtube.com', 'vimeo.com']
+      }), '<iframe></iframe>'
+    );
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -647,21 +647,21 @@ describe('sanitizeHtml', function() {
       }), '<span style="color:yellow;text-align:center;font-family:helvetica;"></span>'
     );
   });
-  it('Should allow only urls in an iframe that are whitelisted', function() {
+  it('Should allow only domains in an iframe that are whitelisted', function() {
     assert.equal(
       sanitizeHtml("<iframe src='https://www.youtube.com/embed/c2IlcS7AHxM'></iframe>", {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
-        allowedUrls: ['youtube.com', 'vimeo.com']
+        allowedIframeDomains: ['youtube.com', 'vimeo.com']
       }), '<iframe src="https://www.youtube.com/embed/c2IlcS7AHxM"></iframe>'
     );
   });
-  it('Should remove iframe src urls that are not whitelisted', function() {
+  it('Should remove iframe src domains that are not whitelisted', function() {
     assert.equal(
       sanitizeHtml("<iframe src='https://www.embed.vevo.com/USUV71704255'></iframe>", {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
-        allowedUrls: ['youtube.com', 'vimeo.com']
+        allowedIframeDomains: ['youtube.com', 'vimeo.com']
       }), '<iframe></iframe>'
     );
   });

--- a/test/test.js
+++ b/test/test.js
@@ -647,21 +647,21 @@ describe('sanitizeHtml', function() {
       }), '<span style="color:yellow;text-align:center;font-family:helvetica;"></span>'
     );
   });
-  it('Should allow only domains in an iframe that are whitelisted', function() {
+  it('Should allow only hostnames in an iframe that are whitelisted', function() {
     assert.equal(
       sanitizeHtml("<iframe src='https://www.youtube.com/embed/c2IlcS7AHxM'></iframe>", {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
-        allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
+        allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
       }), '<iframe src="https://www.youtube.com/embed/c2IlcS7AHxM"></iframe>'
     );
   });
-  it('Should remove iframe src urls that are not inlcuded in whitelisted domains', function() {
+  it('Should remove iframe src urls that are not inlcuded in whitelisted hostnames', function() {
     assert.equal(
       sanitizeHtml("<iframe src='https://www.embed.vevo.com/USUV71704255'></iframe>", {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
-        allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
+        allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
       }), '<iframe></iframe>'
     );
   });
@@ -670,7 +670,7 @@ describe('sanitizeHtml', function() {
       sanitizeHtml("<iframe src='//www.vimeo.com/embed/c2IlcS7AHxM'></iframe>", {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
-        allowedIframeDomains: ['www.youtube.com', 'player.vimeo.com']
+        allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
       }), '<iframe></iframe>'
     );
   });


### PR DESCRIPTION
Hey @boutell looks like I'm the motivated developer 😄 . 

This PR makes it so the user can pass allowable urls as a property to the sanitizeHtml function which will strip out any urls from an iframe tag's src attribute that are not included in the allowable urls property array. 

This is accomplished by just adding a new property to the options object passed to the function like so: 

```
clean = sanitizeHtml(dirty, {
    allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
    allowedAttributes: {
        'iframe': ['src', 'href'],
        'a': ['src', 'href'],
        'img': ['src']
    },
    allowedUrls: ['youtube.com', 'vimeo.com']
})
```

The PR contains some default urls allowed (youtube.com and vimeo.com), I'm happy adjust these or remove them as you see fit. I can simply add a conditional for passing `all` as the only property if that is something you think would be helpful. 

2 passing tests written. 