### PR TITLE
Fix regex in font-size filtering example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ clean = sanitizeHtml(dirty, {
             'color': [/^\#(0x)?[0-9a-f]+$/i, /^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/],
             'text-align': [/^left$/, /^right$/, /^center$/],
             // Match any number with px, em, or %
-            'font-size': [/^\d+$[px|em|\%]$/]
+            'font-size': [/^\d+(?:px|em|%)$/]
           },
           'p': {
             'font-size': [/^\d+rem$/]


### PR DESCRIPTION
Remove stray $ from the example filter for `font-size`.  Use grouping rather than charset for alternatives.

Note might opt to use capture rather than non-capture grouping to make consistent with other examples.