### PR TITLE
Add browser support declaration for packers detection like webpack.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.18.2",
   "description": "Clean up user-submitted HTML, preserving whitelisted elements and whitelisted attributes on a per-element basis",
   "main": "dist/index.js",
+  "browser": "dist/sanitize-html.js",
   "scripts": {
     "prepare": "true",
     "build": "make clean && make all && npm run prepare && browserify dist/index.js > dist/sanitize-html.js --standalone 'sanitizeHtml'",


### PR DESCRIPTION
Avoid packers to use the node version that doesn't transpile es6 code (like ansi-styles one for example).

This currently force all browser user to transpile the code with babel or something else.
With this browser declaration, the transiled version is directly used.