### PR TITLE
allow all schemes if allowedSchemes is set to false

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -443,7 +443,7 @@ function sanitizeHtml(html, options, _recursing) {
       return options.allowedSchemesByTag[name].indexOf(scheme) === -1;
     }
 
-    return !options.allowedSchemes || options.allowedSchemes.indexOf(scheme) === -1;
+    return options.allowedSchemes && options.allowedSchemes.indexOf(scheme) === -1;
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -722,4 +722,10 @@ describe('sanitizeHtml', function() {
         allowedSchemes: sanitizeHtml.defaults.allowedSchemes.concat([ 'tel' ]),
       }), '<q cite=\"http://www.google.com\">HTTP</q><q cite=\"https://www.google.com\">HTTPS</q><q cite=\"mailto://www.google.com\">MAILTO</q><q cite=\"tel://www.google.com\">TEL</q><q cite=\"ftp://www.google.com\">FTP</q><q>DATA</q><q>LDAP</q><q>ACROBAT</q><q>VBSCRIPT</q><q>FILE</q><q>RLOGIN</q><q>WEBCAL</q><q>JAVASCRIPT</q><q>MMS</q>');
   });
+  it('Should allow all schemes if allowedSchemes is false', function() {
+    assert.equal(
+      sanitizeHtml('<a href="byteball:AAA">Click</a>', {
+        allowedSchemes: false
+      }), '<a href="byteball:AAA">Click</a>');
+  });
 });


### PR DESCRIPTION
`allowedTags` and `allowedAttributes` can be set to `false` if user wants to allow all tags and attributes. Similar thing can't be done with `allowedSchemes`, because if `allowedSchemes` is set to `false` `naugtyHref` returns `true`.
If it is desired that setting `allowedSchemes` to `false` should allow all schemes this PR handles that.