### PR TITLE
Revert https://github.com/punkave/sanitize-html/pull/226

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.18.3",
   "description": "Clean up user-submitted HTML, preserving whitelisted elements and whitelisted attributes on a per-element basis",
   "main": "dist/index.js",
-  "browser": "dist/sanitize-html.js",
   "scripts": {
     "prepare": "true",
     "build": "make clean && make all && npm run prepare && browserify dist/index.js > dist/sanitize-html.js --standalone 'sanitizeHtml'",


### PR DESCRIPTION
The 'browser' field should be a node module intended for use in
a web browser, eg. using the `window` object or similar as per
https://docs.npmjs.com/files/package.json#browser . It's what
webpack imports if the key exists. This points it to browserified
source code which isn't what webpack wants.

Also the sanitize-html.js published to npm seems to be an empty
module, I don't know why this is yet, but either way I don't
believe this key should be here. It description says it was to make
packers use the transpiled version rather than the ES6 version,
but it was already pointing at `dist/index.js` which is the babel
transpiled version.

Fixes https://github.com/punkave/sanitize-html/issues/241