### PR TITLE
Add allowIframeRelativeUrls option

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,14 @@ Make sure to pass a valid hostname along with the domain you wish to allow, i.e.
   allowedIframeHostnames: ['www.youtube.com', 'player.vimeo.com']
 ```
 
+You may also specify whether or not to allow relative URLs as iframe sources.
+
+```javascript
+  allowIframeRelativeUrls: true
+```
+
+Note that if unspecified, relative URLs will be allowed by default if no hostname filter is provided but removed by default if a hostname filter is provided.
+
 **Remember that the `iframe` tag must be allowed as well as the `src` attribute.**
 
 For example:

--- a/test/test.js
+++ b/test/test.js
@@ -656,7 +656,7 @@ describe('sanitizeHtml', function() {
       }), '<iframe src="https://www.youtube.com/embed/c2IlcS7AHxM"></iframe>'
     );
   });
-  it('Should remove iframe src urls that are not inlcuded in whitelisted hostnames', function() {
+  it('Should remove iframe src urls that are not included in whitelisted hostnames', function() {
     assert.equal(
       sanitizeHtml('<iframe src="https://www.embed.vevo.com/USUV71704255"></iframe>', {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
@@ -682,12 +682,49 @@ describe('sanitizeHtml', function() {
       }), '<iframe src="https://www.vimeo.com/embed/c2IlcS7AHxM"></iframe>'
     );
   });
-  it('Should allow relative URLs for iframes', function() {
+  it('Should allow relative URLs for iframes by default', function() {
     assert.equal(
       sanitizeHtml('<iframe src="/foo"></iframe>', {
         allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
         allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']}
       }), '<iframe src="/foo"></iframe>'
+    );
+  });
+  it('Should allow relative URLs for iframes', function() {
+    assert.equal(
+      sanitizeHtml('<iframe src="/foo"></iframe>', {
+        allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
+        allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
+        allowIframeRelativeUrls: true,
+      }), '<iframe src="/foo"></iframe>'
+    );
+  });
+  it('Should remove relative URLs for iframes', function() {
+    assert.equal(
+      sanitizeHtml('<iframe src="/foo"></iframe>', {
+        allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
+        allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
+        allowIframeRelativeUrls: false,
+      }), '<iframe></iframe>'
+    );
+  });
+  it('Should remove relative URLs for iframes when whitelisted hostnames specified', function() {
+    assert.equal(
+      sanitizeHtml('<iframe src="/foo"></iframe><iframe src="https://www.youtube.com/embed/c2IlcS7AHxM"></iframe>', {
+        allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
+        allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
+        allowedIframeHostnames: ['www.youtube.com']
+      }), '<iframe></iframe><iframe src="https://www.youtube.com/embed/c2IlcS7AHxM"></iframe>'
+    );
+  });
+  it('Should allow relative and whitelisted hostname URLs for iframes', function() {
+    assert.equal(
+      sanitizeHtml('<iframe src="/foo"></iframe><iframe src="https://www.youtube.com/embed/c2IlcS7AHxM"></iframe>', {
+        allowedTags: ['p', 'iframe', 'a', 'img', 'i'],
+        allowedAttributes: {'iframe': ['src', 'href'], 'a': ['src', 'href'], 'img': ['src']},
+        allowIframeRelativeUrls: true,
+        allowedIframeHostnames: ['www.youtube.com']
+      }), '<iframe src="/foo"></iframe><iframe src="https://www.youtube.com/embed/c2IlcS7AHxM"></iframe>'
     );
   });
   it('Should allow protocol-relative URLs for the right domain for iframes', function() {


### PR DESCRIPTION
The option is pretty self-explanatory, the only real complication is in maintaining the old behavior when no option value is specified.  I added both a comment in the code and a note in the readme explaining that the implicit value (meaning the value when no value set specifically via options) is:

false when allowIframeHostnames specified
true otherwise