### PR TITLE
Remove dependency on postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,13 +26,13 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^2.4.1",
+    "css-tree": "^1.0.0-alpha.29",
     "htmlparser2": "^3.10.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.escaperegexp": "^4.1.2",
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",
     "lodash.mergewith": "^4.6.1",
-    "postcss": "^7.0.5",
     "srcset": "^1.0.0",
     "xtend": "^4.0.1"
   },


### PR DESCRIPTION
`postcss` is a pretty heavy weight dependency if it is only being used for parsing an AST.

Replaced with [css-tree](https://www.npmjs.com/package/css-tree).