### PR TITLE
Add files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.19.3",
   "description": "Clean up user-submitted HTML, preserving whitelisted elements and whitelisted attributes on a per-element basis",
   "main": "dist/index.js",
+  "files": [
+    "dist/"
+  ],
   "scripts": {
     "prepare": "true",
     "build": "make clean && make all && npm run prepare && browserify dist/index.js > dist/sanitize-html.js --standalone 'sanitizeHtml'",


### PR DESCRIPTION
This adds the `files` key to the package.json file which will prevent publishing unnecessary files to npm.

See the docs for more info: https://docs.npmjs.com/files/package.json#files