### PR TITLE
Remove semicolon to close style=""

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -515,11 +515,11 @@ function sanitizeHtml(html, options, _recursing) {
     return filteredAST.nodes[0].nodes
       .reduce(function(extractedAttributes, attributeObject) {
         extractedAttributes.push(
-          attributeObject.prop + ':' + attributeObject.value + ';'
+          attributeObject.prop + ':' + attributeObject.value
         );
         return extractedAttributes;
       }, [])
-      .join('');
+      .join(';');
   }
 
   /**


### PR DESCRIPTION
Hi,

I was trying to validate html on server side with sanitize-html and realized that the plugin was adding a semi-colon on closing style="".
The input was generated by CKEditor4 and looked like this `<div style="width:200px"></div>`
(notice the missing closing semi-colon) which is actually fine according to CSS2 specs that says that semi colon are used to separate, not terminate.

